### PR TITLE
style: use bigeye internal repo for dd image

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -198,7 +198,7 @@ variable "datadog_agent_enabled" {
 variable "datadog_agent_image" {
   description = "The fully qualified image for the datadog agent"
   type        = string
-  default     = "021451147547.dkr.ecr.us-west-2.amazonaws.com/external/datadog/agent:latest"
+  default     = "public.ecr.aws/bigeye/datadog/agent:7.49.0"
 }
 
 variable "datadog_agent_cpu" {


### PR DESCRIPTION
There is a public repo for images that aren't modified (mirrored). Use that one, the internal repo should be retired soon.