### PR TITLE
fix: update deploy so mulitiple deploys run serially

### DIFF
--- a/.github/workflows/test_and_publish.yaml
+++ b/.github/workflows/test_and_publish.yaml
@@ -9,6 +9,11 @@ on:
   pull_request:
     paths:
       - modules/**/*
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   directories:
     name: List directories

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
+# Node
 node_modules
+
+# Terraform
 .terraform
 modules/**/.terraform.lock.hcl
+
+# Intellij
 .idea
+*.iml
+


### PR DESCRIPTION
We don't want to deploy in parallel if there are several merges.