### PR TITLE
fix: use bigeye as the default mysql db name for the app db

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1518,7 +1518,7 @@ module "datawatch_rds" {
   name   = "${local.name}-datawatch"
 
   # Connection Info
-  db_name                       = "toro"
+  db_name                       = var.datawatch_rds_db_name
   root_user_name                = "bigeye"
   root_user_password_secret_arn = local.datawatch_rds_password_secret_arn
   snapshot_identifier           = var.datawatch_rds_snapshot_identifier

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -720,6 +720,12 @@ variable "datawatch_robot_password_secret_arn" {
   default     = ""
 }
 
+variable "datawatch_rds_db_name" {
+  description = "The database name for Datawatch's application DB"
+  type        = string
+  default     = "bigeye"
+}
+
 variable "datawatch_rds_snapshot_identifier" {
   description = "The snapshot identifier of the snapshot to create the database from"
   type        = string


### PR DESCRIPTION
toro is part of a legacy naming convention that does not need to be carried into the future

BREAKING CHANGE: Existing installs will need to set the `datawatch_rds_db_name = 'toro'` variable or the upgrade will destroy the application database will all application settings (including users etc).