### PR TITLE
fix: update temporal LB SG to allow 443

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -786,8 +786,8 @@ resource "aws_security_group" "temporal_lb" {
 
   ingress {
     description = "Traffic port open to anywhere"
-    from_port   = 7233
-    to_port     = 7233
+    from_port   = 443
+    to_port     = 443
     protocol    = "TCP"
     cidr_blocks = var.temporal_internet_facing ? ["0.0.0.0/0"] : [var.vpc_cidr_block]
   }

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -905,49 +905,58 @@ resource "aws_ecs_task_definition" "temporal" {
         }
       }
       portMappings = [
-        {
-          containerPort = 6939
-          hostPort      = 6939
-          protocol      = "tcp"
-        },
-        {
-          containerPort = 7233
-          hostPort      = 7233
-          protocol      = "tcp"
-        },
-        {
-          containerPort = 7235
-          hostPort      = 7235
-          protocol      = "tcp"
-        },
-        {
-          containerPort = 7239
-          hostPort      = 7239
-          protocol      = "tcp"
-        },
-        {
-          containerPort = 9091
-          hostPort      = 9091
-          protocol      = "tcp"
-        },
-        {
-          containerPort = 6934
-          hostPort      = 6934
-          protocol      = "tcp"
-        },
+        # Frontend service membership
         {
           containerPort = 6933
           hostPort      = 6933
           protocol      = "tcp"
         },
+        # History service membership
+        {
+          containerPort = 6934
+          hostPort      = 6934
+          protocol      = "tcp"
+        },
+        # Matching service membership
         {
           containerPort = 6935
           hostPort      = 6935
           protocol      = "tcp"
         },
+        # Worker service membership
+        {
+          containerPort = 6939
+          hostPort      = 6939
+          protocol      = "tcp"
+        },
+        # Frontend service handler (API)
+        {
+          containerPort = 7233
+          hostPort      = 7233
+          protocol      = "tcp"
+        },
+        # History service handler
         {
           containerPort = 7234
           hostPort      = 7234
+          protocol      = "tcp"
+        },
+        # Matching service handler
+        {
+          containerPort = 7235
+          hostPort      = 7235
+          protocol      = "tcp"
+        },
+        # Worker service handler
+        {
+          containerPort = 7239
+          hostPort      = 7239
+          protocol      = "tcp"
+        },
+        # Prometheus
+        {
+          containerPort = 9091
+          hostPort      = 9091
           protocol      = "tcp"
         },
       ]


### PR DESCRIPTION
The entrypoint for all services should be 80/443.  This is a bug fix as 7233 is the internal service port, but we are serving traffic on 443 via the LB so the SG should allow 443.