### PR TITLE
Add validation messages and fixes

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -88,14 +88,14 @@ locals {
     STITCH_API_TOKEN = var.stitch_api_token_secretsmanager_arn
   }
 
-  datawatch_additional_security_groups = concat(
+  datawatch_additional_security_groups = var.create_security_groups ? concat(
     [
       module.redis.client_security_group_id,
       module.rabbitmq.client_security_group_id,
       module.datawatch_rds.client_security_group_id
     ],
     var.datawatch_rds_replica_enabled ? [module.datawatch_rds.replica_client_security_group_id] : []
-  )
+  ) : []
 
   datawatch_secret_arns = merge(
     local.auth0_secrets_map,

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -132,6 +132,11 @@ data "aws_vpc" "this" {
       condition     = (!local.create_vpc && length(var.byovpc_database_subnet_group_name) > 0) || (local.create_vpc && length(var.byovpc_database_subnet_group_name) == 0)
       error_message = "if byovpc_vpc_id is specified, byovpc_database_subnet_group_name must be specified, otherwise it must be empty"
     }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.rabbitmq_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide RabbitMQ a security group using rabbitmq_extra_security_group_ids (port 5671)"
+    }
   }
 }
 

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1287,7 +1287,7 @@ module "monocle" {
   vpc_cidr_block                = var.vpc_cidr_block
   subnet_ids                    = local.application_subnet_ids
   create_security_groups        = var.create_security_groups
-  additional_security_group_ids = concat([module.rabbitmq.client_security_group_id], var.monocle_extra_security_group_ids)
+  additional_security_group_ids = var.create_security_groups ? concat([module.rabbitmq.client_security_group_id], var.monocle_extra_security_group_ids) : var.monocle_extra_security_group_ids
   traffic_port                  = var.monocle_port
   ecs_cluster_id                = aws_ecs_cluster.this.id
   fargate_version               = var.fargate_version
@@ -1366,7 +1366,7 @@ module "toretto" {
   vpc_cidr_block                = var.vpc_cidr_block
   subnet_ids                    = local.application_subnet_ids
   create_security_groups        = var.create_security_groups
-  additional_security_group_ids = concat([module.rabbitmq.client_security_group_id], var.toretto_extra_security_group_ids)
+  additional_security_group_ids = var.create_security_groups ? concat([module.rabbitmq.client_security_group_id], var.toretto_extra_security_group_ids) : var.toretto_extra_security_group_ids
   traffic_port                  = var.toretto_port
   ecs_cluster_id                = aws_ecs_cluster.this.id
   fargate_version               = var.fargate_version
@@ -1443,7 +1443,7 @@ module "scheduler" {
   vpc_cidr_block                = var.vpc_cidr_block
   subnet_ids                    = local.application_subnet_ids
   create_security_groups        = var.create_security_groups
-  additional_security_group_ids = concat([module.redis.client_security_group_id], var.scheduler_extra_security_group_ids)
+  additional_security_group_ids = var.create_security_groups ? concat([module.redis.client_security_group_id], var.scheduler_extra_security_group_ids) : var.scheduler_extra_security_group_ids
   traffic_port                  = var.scheduler_port
   ecs_cluster_id                = aws_ecs_cluster.this.id
   fargate_version               = var.fargate_version

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1486,6 +1486,7 @@ module "scheduler" {
     DEPLOY_TYPE           = "AWS"
     DATAWATCH_ADDRESS     = "https://${local.datawatch_dns_name}"
     MAX_RAM_PERCENTAGE    = "85"
+    SCHEDULER_ADDRESS     = "http://localhost:${var.scheduler_port}"
     SCHEDULER_THREADS     = var.scheduler_threads
     SENTRY_DSN            = var.sentry_dsn
     REDIS_PRIMARY_ADDRESS = module.redis.primary_endpoint_dns_name

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -187,6 +187,56 @@ data "aws_vpc" "this" {
       condition     = var.create_security_groups || length(var.metricwork_lb_extra_security_group_ids) > 0
       error_message = "If create_security_groups is false, you must provide a security group for the metricwork lb using metricwork_lb_extra_security_group_ids (ports 80/443)"
     }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.haproxy_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the HAProxy ECS tasks using haproxy_extra_security_group_ids (ports ${var.haproxy_port})"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.web_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the web ECS tasks using web_extra_security_group_ids (ports ${var.web_port})"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.monocle_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the monocle ECS tasks using monocle_extra_security_group_ids (ports ${var.monocle_port})"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.toretto_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the toretto ECS tasks using toretto_extra_security_group_ids (ports ${var.toretto_port})"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.temporalui_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the temporalui ECS tasks using temporalui_extra_security_group_ids (ports ${var.temporalui_port})"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.temporal_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the temporal ECS tasks using temporal_extra_security_group_ids (port 7233)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.scheduler_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the scheduler ECS tasks using scheduler_extra_security_group_ids (ports ${var.scheduler_port})"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.datawatch_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the datawatch ECS tasks using datawatch_extra_security_group_ids (ports ${var.datawatch_port})"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.datawork_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the datawork ECS tasks using datawork_extra_security_group_ids (port ${var.datawork_port})"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.metricwork_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the metricwork ECS tasks using metricwork_extra_security_group_ids (port ${var.metricwork_port})"
+    }
   }
 }
 

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -817,6 +817,7 @@ module "temporal_rds" {
   max_allocated_storage                 = var.temporal_rds_max_allocated_storage
   storage_type                          = "gp3"
   db_subnet_group_name                  = local.database_subnet_group_name
+  create_security_groups                = var.create_security_groups
   extra_security_group_ids              = var.temporal_rds_extra_security_group_ids
   instance_class                        = var.temporal_rds_instance_type
   backup_window                         = var.rds_backup_window
@@ -1635,6 +1636,7 @@ module "datawatch_rds" {
   #Networking
   vpc_id                   = local.vpc_id
   db_subnet_group_name     = local.database_subnet_group_name
+  create_security_groups   = var.create_security_groups
   extra_security_group_ids = var.datawatch_rds_extra_security_group_ids
   enable_multi_az          = var.redundant_infrastructure ? true : false
 

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -137,6 +137,56 @@ data "aws_vpc" "this" {
       condition     = var.create_security_groups || length(var.rabbitmq_extra_security_group_ids) > 0
       error_message = "If create_security_groups is false, you must provide RabbitMQ a security group using rabbitmq_extra_security_group_ids (port 5671)"
     }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.haproxy_lb_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the HAProxy lb using haproxy_lb_extra_security_group_ids (ports 80/443)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.web_lb_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the web lb using web_lb_extra_security_group_ids (ports 80/443)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.monocle_lb_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the monocle lb using monocle_lb_extra_security_group_ids (ports 80/443)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.toretto_lb_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the toretto lb using toretto_lb_extra_security_group_ids (ports 80/443)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.temporalui_lb_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the temporalui lb using temporalui_lb_extra_security_group_ids (ports 80/443)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.temporal_lb_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the temporal lb using temporal_lb_extra_security_group_ids (port 443)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.scheduler_lb_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the scheduler lb using scheduler_lb_extra_security_group_ids (ports 80/443)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.datawatch_lb_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the datawatch lb using datawatch_lb_extra_security_group_ids (ports 80/443)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.datawork_lb_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the datawork lb using datawork_lb_extra_security_group_ids (ports 80/443)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.metricwork_lb_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide a security group for the metricwork lb using metricwork_lb_extra_security_group_ids (ports 80/443)"
+    }
   }
 }
 

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1853,7 +1853,7 @@ module "datawatch" {
       INSTANCE                        = var.instance
       PORT                            = var.datawatch_port
       APP                             = "datawatch"
-      MYSQL_JDBC                      = "jdbc:mysql://${local.datawatch_mysql_dns_name}:3306/toro?serverTimezone=UTC"
+      MYSQL_JDBC                      = "jdbc:mysql://${local.datawatch_mysql_dns_name}:3306/${var.datawatch_rds_db_name}?serverTimezone=UTC"
       MYSQL_USER                      = "bigeye"
       MYSQL_MAXSIZE                   = var.datawatch_mysql_maxsize
       MYSQL_TRANSACTION_ISOLATION     = "default"
@@ -1952,7 +1952,7 @@ module "datawork" {
       INSTANCE                     = var.instance
       PORT                         = var.datawork_port
       APP                          = "datawork"
-      MYSQL_JDBC                   = "jdbc:mysql://${local.datawatch_mysql_dns_name}:3306/toro?serverTimezone=UTC"
+      MYSQL_JDBC                   = "jdbc:mysql://${local.datawatch_mysql_dns_name}:3306/${var.datawatch_rds_db_name}?serverTimezone=UTC"
       MYSQL_USER                   = "bigeye"
       MYSQL_MAXSIZE                = var.datawatch_mysql_maxsize
       MYSQL_TRANSACTION_ISOLATION  = "default"
@@ -2053,7 +2053,7 @@ module "metricwork" {
       INSTANCE                     = var.instance
       PORT                         = var.metricwork_port
       APP                          = "metricwork"
-      MYSQL_JDBC                   = "jdbc:mysql://${local.datawatch_mysql_dns_name}:3306/toro?serverTimezone=UTC"
+      MYSQL_JDBC                   = "jdbc:mysql://${local.datawatch_mysql_dns_name}:3306/${var.datawatch_rds_db_name}?serverTimezone=UTC"
       MYSQL_USER                   = "bigeye"
       MYSQL_MAXSIZE                = var.datawatch_mysql_maxsize
       MYSQL_TRANSACTION_ISOLATION  = "default"

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -139,6 +139,21 @@ data "aws_vpc" "this" {
     }
 
     postcondition {
+      condition     = var.create_security_groups || length(var.redis_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide Redis a security group using redis_extra_security_group_ids (port 6379)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.datawatch_rds_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide the Datawatch RDS instance a security group using datawatch_rds_extra_security_group_ids (port 3306)"
+    }
+
+    postcondition {
+      condition     = var.create_security_groups || length(var.temporal_rds_extra_security_group_ids) > 0
+      error_message = "If create_security_groups is false, you must provide the Temporal RDS instance a security group using temporal_rds_extra_security_group_ids (port 3306)"
+    }
+
+    postcondition {
       condition     = var.create_security_groups || length(var.haproxy_lb_extra_security_group_ids) > 0
       error_message = "If create_security_groups is false, you must provide a security group for the HAProxy lb using haproxy_lb_extra_security_group_ids (ports 80/443)"
     }

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -91,7 +91,7 @@ module "this" {
   create_db_subnet_group = false
   db_subnet_group_name   = var.db_subnet_group_name
   multi_az               = var.enable_multi_az
-  vpc_security_group_ids = concat([aws_security_group.db[0].id], var.extra_security_group_ids)
+  vpc_security_group_ids = var.create_security_groups ? concat([aws_security_group.db[0].id], var.extra_security_group_ids) : var.extra_security_group_ids
 
   allocated_storage     = var.allocated_storage
   max_allocated_storage = var.max_allocated_storage
@@ -141,7 +141,7 @@ module "replica" {
   port                   = 3306
   create_db_subnet_group = false
   multi_az               = false
-  vpc_security_group_ids = concat([aws_security_group.db_replica[0].id], var.extra_security_group_ids)
+  vpc_security_group_ids = var.create_security_groups ? concat([aws_security_group.db_replica[0].id], var.extra_security_group_ids) : var.extra_security_group_ids
 
   allocated_storage     = var.allocated_storage
   max_allocated_storage = var.max_allocated_storage


### PR DESCRIPTION
Adds several conditions and error messages for validating that users provide the necessary data when they are managing the security groups, namely when `create_security_groups` is false.

Fixes several places where `create_security_groups=false` was not being respected.

Adds an environment variable to scheduler so it can talk to itself on the traffic port (default `80`).