### PR TITLE
fix: reduce time it takes to mark ECS nodes as healthy

### DIFF
--- a/modules/simpleservice/main.tf
+++ b/modules/simpleservice/main.tf
@@ -86,7 +86,7 @@ resource "aws_lb_target_group" "this" {
   health_check {
     enabled             = true
     protocol            = "HTTP"
-    healthy_threshold   = 5
+    healthy_threshold   = 2
     unhealthy_threshold = 10
     interval            = var.healthcheck_interval
     timeout             = 10


### PR DESCRIPTION
We are waiting a long time before marking a node as healthy. Especially for background workers, this can result in unecessary ECS task termination.

Basically 5 x 90s = 7.5min before we mark a metricwork node as healthy again.