### PR TITLE
feat: add VPC endpoints for resources required for ECS

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -313,6 +313,15 @@ module "vpc_endpoints" {
         module.vpc[0].public_route_table_ids
       )
     }
+    ecr_api = {
+      service             = "ecr.api"
+      service_type        = "Interface"
+      subnet_ids          = local.application_subnet_ids
+      private_dns_enabled = true
+      tags = merge(local.tags, {
+        Name = "${local.name}-ecrapi-endpoint"
+      })
+    }
     ecr_dkr = {
       service             = "ecr.dkr"
       service_type        = "Interface"
@@ -320,6 +329,24 @@ module "vpc_endpoints" {
       private_dns_enabled = true
       tags = merge(local.tags, {
         Name = "${local.name}-ecrdkr-endpoint"
+      })
+    }
+    logs = {
+      service             = "logs"
+      service_type        = "Interface"
+      subnet_ids          = local.application_subnet_ids
+      private_dns_enabled = true
+      tags = merge(local.tags, {
+        Name = "${local.name}-logs-endpoint"
+      })
+    }
+    secretsmanager = {
+      service             = "secretsmanager"
+      service_type        = "Interface"
+      subnet_ids          = local.application_subnet_ids
+      private_dns_enabled = true
+      tags = merge(local.tags, {
+        Name = "${local.name}-secretsmanager-endpoint"
       })
     }
   }


### PR DESCRIPTION
This will help keep important traffic off of public net (like ASM) as well as reduce ingress and egress costs for data transfers (like image pulls and ML models stored in s3).

There is a ~$8/mo per AZ charge for VPCe's so I opted not to add ones that are there just for the admin container debugging.  It's not critical for that traffic to stay off of private net anyhow.