### PR TITLE
feat: add BYO mTLS certs example

### DIFF
--- a/examples/self-managed-mtls-certs/README.md
+++ b/examples/self-managed-mtls-certs/README.md
@@ -1,0 +1,77 @@
+# Self-Managed mTLS certs Installation
+
+Bigeye images ship with a set of default mTLS certs for communication
+between the Temporal service and the other services.  These certs are
+included for ease of installation, but are not meant for use in production.
+
+For production installations, it is recommended to generate your own
+SSL certs, whether they be self signed or otherwise, so that they are
+unique for your environment.
+
+The method for Bigeye to use your self-managed SSL certs is to store them
+in AWS Secrets manager (ASM) as base64 encoded strings.  Details on how to
+do this are in the steps below.
+
+## Prerequisites
+
+* AWS CLI setup (aws sts get-caller-identity should run without error)
+* AWS user has access to create / modify secret in ASM
+* openssl, tar, gzip, base64 work from local bash shell
+
+## Steps
+
+1. Install Bigeye using the default mTLS certs (ie follow the minimal or standard example).  It is best to get this up and running with the default certs first to reduce the number of moving parts to check when the self-managed mTLS certs are introduced. 
+2. Generate a set of self-signed certs (omit this step if you are bringing your own generated certs)
+
+Take note of the following Terraform outputs from Step 1.
+* `stack_name` - ASM secrets tagged with stack:<stack_name> will be readable by the Bigeye ECS cluster
+* `temporal_dns_name` - This is used for SSL hostname verification, self signed certs will be created for this hostname.
+
+Run the following script, it will generate a set of self-signed certs and upload it to ASM at /bigeye/byo-mtls-example/*
+```
+./generate_self_signed_mtls_certs.sh  -a <temporal_dns_name> -s <stack_name> -u /bigeye/byo-mtls-example
+```
+Take note of the ARNs for the ASM secrets that were created as those will be used in a later step.
+
+Skip to Step 5.
+
+3. Store mTLS certs as base64 encoded strings in ASM.
+
+For bringing your own certs, the files need to be stored in ASM as base64 encoded strings (ie secret_value = cat $file | base64).
+
+You will need 4 files
+* public CA (pem)
+* public cert (pem) that was generated from the CA
+* private cert (key) that was generated from the CA
+* ca bundle (tgz).  Basically a tar where there is 1 file in it - the public CA.  This tar should then be gzipped so the final file is a tgz.  See
+the `generate_trust_bundle()` function in [generate_self_signed_mtls_certs.sh](./generate_self_signed_mtls_certs.sh) for an example of how to generate this.
+
+Once you have the files, base64 encode them (cat $file | base64) and upload that string to ASM.  You will have 1 ASM secret per file, ensure no newlines are present in the uploaded secret.
+4. Add a tag to your ASM secrets to grant the ECS cluster access to the secrets. Key = stack, value = `stack_name`.  `stack_name` is one of the Terraform outputs in Step 1.
+5. Add the *_additional_secret_arns to the Bigeye terraform module as shown in [main.tf](./main.tf) to point Bigeye at your custom SSL certs and run terraform apply.  If you used [generate_self_signed_mtls_certs.sh](./generate_self_signed_mtls_certs.sh) to generate the certs, the ARNs will be in the output from that script. 
+6. Go to the ECS web ui and manually stop all tasks associated with the Temporal service as there will be conflict between the existing Temporal service running with
+default mTLS certs and the new one that is trying to start up with your custom certs.  ECS will automatically restart after a minute or two.
+
+## Configuration
+
+The following variables are required to use your own custom mTLS certs:
+
+* `temporal_use_default_certificates` - set this to false to use custom mTLS certs
+* `datawatch_additional_secret_arns` - this is a set ASM secrets that will be used by the datawatch service to connect to Temporal - see [main.tf](./main.tf) for implementation
+* `temporal_additional_secret_arns` = this is a set ASM secrets that will be used by the temporal service for connections from all clients - see [main.tf](./main.tf) for implementation
+* `temporalui_additional_secret_arns` = this is a set ASM secrets that will be used by the temporalui service to connect to Temporal - see [main.tf](./main.tf) for implementation
+
+The certs required by Bigeye will be
+- root ca public key (pem) - this is used by client and server to trust certificate pairs
+- public cert generated from the root ca (pem)
+- private cert generated from the root ca (key)
+
+The same public/private key pair will be used on both client and server side in this example for the sake of simplicity. 
+If desired, datawatch, temporal, and temporalui can use different public/private key pairs as long as they are all 
+generated from the same root ca.
+
+A sample configuration can be found in [main.tf](./main.tf).
+
+## Scripts
+Also included in this example is a helper script to generate a set of self-signed certs and upload them to ASM.  This can be run with -h for more detail.
+- generate_self_signed_mtls_certs.sh

--- a/examples/self-managed-mtls-certs/generate_self_signed_mtls_certs.sh
+++ b/examples/self-managed-mtls-certs/generate_self_signed_mtls_certs.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+# Description: Generate ca and public/private key pair for use in mTLS
+set -e
+
+function usage {
+  echo
+  echo "Usage: $0 -a <address> -s <stack_name> [-c <company>] [-u <asm_prefix>]"
+  echo
+  echo "-a <address> - Temporal service address. Example: bigeye-workflows.example.com.  This is the temporal_dns_name output from the Bigeye terraform module"
+  echo "-c <company> - This is used in the dn field when generating SSL certs and is optional.  default=Bigeye"
+  echo "-s <stack_name> - This is the stack_name output from the Bigeye terraform module and is used for tagging the AWS secrets manager secret with stack=<stack_name>.  This grants access to the secret for the Bigeye ECS cluster."
+  echo "-u <asm_prefix> - Use -u to also upload the generated certs to AWS Secrets manager.  The prefix will be used as the first part of the secret name for the files"
+  echo "    example: if asm_prefix = /bigeye/mtls, then the files will be uploaded as /bigeye/mtls/{mtls_ca_pem, mtls_pem, mtls_key, mtls_client_ca_bundle_tgz}"
+  echo
+  echo "There will be 4 files that are generated that will be used by the Bigeye stack"
+  echo "${CERTS_DIR}/${CERT_FILE_PREFIX}_ca.pem - ca public cert.  Will be imported as SECRETS_TEMPORAL_PUBLIC_MTLS_CA_BASE64"
+  echo "${CERTS_DIR}/${CERT_FILE_PREFIX}.pem - public cert.  Will be imported as SECRETS_TEMPORAL_PUBLIC_MTLS_BASE64"
+  echo "${CERTS_DIR}/${CERT_FILE_PREFIX}.key - private key.  Will be imported as SECRETS_TEMPORAL_PRIVATE_MTLS_BASE64"
+  echo "${CERTS_DIR}/${CERT_FILE_PREFIX}_client_ca_bundle.tgz - tar ball of ca's that Temporal will trust certs for.  Will be imported as SECRETS_TEMPORAL_MTLS_CA_BUNDLE_BASE64"
+  echo
+  exit 1
+}
+
+function set_defaults {
+  export CERT_FILE_PREFIX=mtls
+  export COMPANY=Bigeye
+  export CERTS_DIR="./mtls_certs"
+}
+
+function print_log {
+  echo ">>> ${1}"
+}
+
+function print_warning {
+  echo ">>> ****"
+  echo ">>> **** ${1}"
+  echo ">>> ****"
+}
+
+function generate_server_ca() {
+  local company temporal_address certs_dir conf_file
+  company="$1"
+  temporal_address="$2"
+  certs_dir="$3"
+  conf_file="${certs_dir}/ca.conf"
+
+  print_log "Generate a private key and a certificate for a certificate authority"
+
+  cat >"$conf_file" << EOF
+[req]
+default_bits = 4096
+default_md = sha256
+req_extensions = req_ext
+x509_extensions = v3_ca
+distinguished_name = dn
+prompt = no
+[v3_ca]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,digitalSignature,cRLSign,keyCertSign
+[req_ext]
+subjectAltName = @alt_names
+[dn]
+O = $company
+[alt_names]
+DNS.1 = $temporal_address
+EOF
+
+  openssl genrsa -out "${certs_dir}/${CERT_FILE_PREFIX}_ca.key" 4096
+  openssl req -new -x509 -days 365 -key "${certs_dir}/${CERT_FILE_PREFIX}_ca.key" -out "${certs_dir}/${CERT_FILE_PREFIX}_ca.pem" -config "$conf_file"
+
+  rm "$conf_file"
+  echo Done.
+}
+
+function generate_server_certs() {
+  local company temporal_address certs_dir conf_file
+  company="$1"
+  temporal_address="$2"
+  certs_dir="$3"
+  conf_file="${certs_dir}/client_certs.conf"
+
+  print_log "Generating client key pair"
+  cat <<-EOF >"${conf_file}"
+[req]
+default_bits = 4096
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+prompt = no
+[req_ext]
+subjectAltName = @alt_names
+[dn]
+C = US
+ST = CA
+O = $company
+[alt_names]
+DNS.1 = $temporal_address
+EOF
+
+  # Generate client's private key and certificate signing request (CSR)
+  openssl req -newkey rsa:4096 -nodes -keyout "${certs_dir}/${CERT_FILE_PREFIX}.key" -out "${certs_dir}/${CERT_FILE_PREFIX}.csr" -config "$conf_file"
+  # Use CA's private key to sign client's CSR and get back the signed certificate
+  openssl x509 -days 365 -req -in "${certs_dir}/${CERT_FILE_PREFIX}.csr" -CA "${certs_dir}/${CERT_FILE_PREFIX}_ca.pem" -CAkey "${certs_dir}/${CERT_FILE_PREFIX}_ca.key" -CAcreateserial -out "${certs_dir}/${CERT_FILE_PREFIX}.pem" -extfile "$conf_file" -extensions req_ext
+  # Delete the certificate signing request after the certificate has been signed.
+  rm "${certs_dir}/${CERT_FILE_PREFIX}.csr"
+
+  rm "$conf_file"
+  echo "Done."
+}
+
+function generate_trust_bundle() {
+  local certs_dir ca_file
+  certs_dir="$1"
+  ca_file="${CERT_FILE_PREFIX}_ca.pem"
+
+  print_log
+  tar -r -C "${certs_dir}" -f "${certs_dir}/${CERT_FILE_PREFIX}_client_ca_bundle.tar" "$ca_file"
+  gzip "${certs_dir}/${CERT_FILE_PREFIX}_client_ca_bundle.tar"
+}
+
+function aws_credentials_valid() {
+  aws sts get-caller-identity
+}
+
+function upsert_secret_file() {
+  local cert_file secret_id tags b64_string stack
+  cert_file="$1"
+  secret_id="$2"
+  stack="$3"
+  tags="[{\"Key\": \"stack\", \"Value\": \"$stack\"},{\"Key\": \"app\", \"Value\": \"bigeye\"}]"
+
+  print_log "Uploading $cert_file to AWS secrets manager $secret_id base64 encoded."
+  # shellcheck disable=SC2002
+  b64_string=$(cat "${cert_file}" | base64)
+  # shellcheck disable=SC2086
+  aws secretsmanager create-secret --name "${secret_id}" --secret-string "$b64_string" 2>/dev/null ||
+    aws secretsmanager put-secret-value --secret-id "${secret_id}" --secret-string "$b64_string"
+  aws secretsmanager tag-resource --secret-id "${secret_id}" --tags "$tags"
+}
+
+function upload_to_aws_secrets_manager() {
+  local certs_dir secret_id_prefix stack
+  certs_dir="$1"
+  secret_id_prefix="$2"
+  stack="$3"
+
+  for fq_file in "${certs_dir}"/*; do
+    file=$(basename "$fq_file")
+    # secred id is the file name with dots replaced by underscores
+    upsert_secret_file "${certs_dir}/${file}" "${secret_id_prefix}/${file//./_}" "$stack"
+  done
+}
+
+##############
+# BEGIN MAIN #
+##############
+set_defaults
+while getopts "ha:c:s:u:" opt; do
+  case $opt in
+  h)
+    usage
+    ;;
+  a)
+    TEMPORAL_ADDRESS="$OPTARG"
+    ;;
+  c)
+    COMPANY="$OPTARG"
+    ;;
+  s)
+    STACK="$OPTARG"
+    ;;
+  u)
+    SECRET_ID_PREFIX="$OPTARG"
+    ;;
+  *)
+    usage
+    ;;
+  esac
+done
+
+if [ -z "$TEMPORAL_ADDRESS" ]; then
+  print_warning "-a <temporal address> is a required arg"
+  usage
+fi
+if [ -z "$STACK" ]; then
+  print_warning "-s <stack_name> is a required arg"
+  usage
+fi
+if [[ -x "$CERTS_DIR" ]]; then
+  echo
+  print_warning "Existing cert dir already exists: $CERTS_DIR.  Remove it first and re-run if you wish to continue."
+  echo
+  exit 1
+fi
+
+echo
+echo "CERTS_DIR: $CERTS_DIR"
+echo "COMPANY: $COMPANY"
+echo "SECRET_ID_PREFIX: $SECRET_ID_PREFIX"
+echo "STACK: $STACK"
+echo "TEMPORAL_ADDRESS: $TEMPORAL_ADDRESS"
+echo
+
+mkdir -p "$CERTS_DIR"
+
+generate_server_ca "$COMPANY" "$TEMPORAL_ADDRESS" "$CERTS_DIR"
+generate_server_certs "$COMPANY" "$TEMPORAL_ADDRESS" "$CERTS_DIR"
+generate_trust_bundle "$CERTS_DIR"
+
+echo
+print_log "Output files:"
+print_log "${CERTS_DIR}/${CERT_FILE_PREFIX}_ca.key - used to generate certs, Bigeye services will not need this."
+print_log "${CERTS_DIR}/${CERT_FILE_PREFIX}_ca.pem - ca public cert.  Will be imported as SECRETS_TEMPORAL_PUBLIC_MTLS_CA_BASE64"
+print_log "${CERTS_DIR}/${CERT_FILE_PREFIX}.pem - public cert.  Will be imported as SECRETS_TEMPORAL_PUBLIC_MTLS_BASE64"
+print_log "${CERTS_DIR}/${CERT_FILE_PREFIX}.key - private key.  Will be imported as SECRETS_TEMPORAL_PRIVATE_MTLS_BASE64"
+print_log "${CERTS_DIR}/${CERT_FILE_PREFIX}_client_ca_bundle.tgz - tar ball of ca's that Temporal will trust certs for.  Will be imported as SECRETS_TEMPORAL_MTLS_CA_BUNDLE_BASE64"
+echo
+
+if [[ -z "$SECRET_ID_PREFIX" ]]; then
+  print_log "-u was not specified.  Skipping upload to AWS secrets manager."
+else
+  aws_credentials_valid
+  upload_to_aws_secrets_manager "$CERTS_DIR" "$SECRET_ID_PREFIX" "$STACK"
+fi
+
+echo
+print_log "Success!"
+echo
+
+# This can be used to verify the generated certs
+# openssl x509 -noout -text -in <cert file>

--- a/examples/self-managed-mtls-certs/main.tf
+++ b/examples/self-managed-mtls-certs/main.tf
@@ -1,0 +1,49 @@
+data "aws_secretsmanager_secret" "private" {
+  name = "bigeye/byo-mtls-example/mtls_key"
+}
+
+data "aws_secretsmanager_secret" "public" {
+  name = "bigeye/byo-mtls-example/mtls_pem"
+}
+
+data "aws_secretsmanager_secret" "ca_public" {
+  name = "bigeye/byo-mtls-example/mtls_ca_pem"
+}
+
+data "aws_secretsmanager_secret" "ca_bundle" {
+  name = "bigeye/byo-mtls-example/mtls_client_ca_bundle_tar_gz"
+}
+
+module "bigeye" {
+  source      = "git::https://github.com/bigeyedata/terraform-modules//modules/bigeye?ref=v1.8.0"
+  environment = "test"
+  instance    = "bigeye"
+
+  # Bigeye app version.  You can list the tags available in the image_registry (using the latest is always recommended).
+  image_tag = "1.35.0"
+
+  temporal_use_default_certificates = false
+
+  datawatch_additional_secret_arns = {
+    SECRETS_TEMPORAL_PUBLIC_MTLS_BASE64    = data.aws_secretsmanager_secret.public.arn
+    SECRETS_TEMPORAL_PRIVATE_MTLS_BASE64   = data.aws_secretsmanager_secret.private.arn
+    SECRETS_TEMPORAL_PUBLIC_MTLS_CA_BASE64 = data.aws_secretsmanager_secret.ca_public.arn
+    SECRETS_TEMPORAL_MTLS_CA_BUNDLE_BASE64 = data.aws_secretsmanager_secret.ca_bundle.arn
+  }
+  temporal_additional_secret_arns = {
+    SECRETS_TEMPORAL_PUBLIC_MTLS_BASE64    = data.aws_secretsmanager_secret.public.arn
+    SECRETS_TEMPORAL_PRIVATE_MTLS_BASE64   = data.aws_secretsmanager_secret.private.arn
+    SECRETS_TEMPORAL_PUBLIC_MTLS_CA_BASE64 = data.aws_secretsmanager_secret.ca_public.arn
+    SECRETS_TEMPORAL_MTLS_CA_BUNDLE_BASE64 = data.aws_secretsmanager_secret.ca_bundle.arn
+  }
+  temporalui_additional_secret_arns = {
+    TEMPORAL_TLS_CERT_DATA = data.aws_secretsmanager_secret.public.arn
+    TEMPORAL_TLS_KEY_DATA  = data.aws_secretsmanager_secret.private.arn
+    TEMPORAL_TLS_CA_DATA   = data.aws_secretsmanager_secret.ca_public.arn
+  }
+}
+
+# This output is just here for debugging and can be removed if desired.  It is used to get the temporal_dns_name for use in setting up mTLS certs.
+output "bigeye" {
+  value = module.bigeye
+}

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -1,3 +1,8 @@
+output "stack_name" {
+  description = "Top level stack name for the Bigeye app resources.  This is used in tags, for AWS secrets manager access etc."
+  value       = local.stack_name
+}
+
 output "vpc_id" {
   description = "The VPC ID holding resources"
   value       = local.vpc_id
@@ -191,6 +196,10 @@ output "web_load_balancer_zone_id" {
   value       = module.web.zone_id
 }
 
+output "ecs_task_role_id" {
+  description = "Id of the ECS Task execution role.  This is useful for granting ECS access to secrets manager secrets."
+  value       = aws_iam_role.ecs.id
+}
 #======================================================
 # Networking bits
 #======================================================


### PR DESCRIPTION
This is an example install for BYO mTLS certs which includes a script to generate a set of self-signed certs that can be used for this purpose.

There is one actual module update, which is to output the ECS role ID as that is will need to be used by installers to grant AWS secrets manager (ASM) access to the mTLS certs stored in ASM.