### PR TITLE
docs: add top_level_dns_name to self-managed-mtls-certs example

### DIFF
--- a/examples/self-managed-mtls-certs/main.tf
+++ b/examples/self-managed-mtls-certs/main.tf
@@ -19,6 +19,10 @@ module "bigeye" {
   environment = "test"
   instance    = "bigeye"
 
+  # This is domain name of the domain that you have already set up in route53.  This terraform will create DNS entries
+  # in that domain for the application.
+  top_level_dns_name = "example.com"
+
   # Bigeye app version.  You can list the tags available in the image_registry (using the latest is always recommended).
   image_tag = "1.35.0"
 


### PR DESCRIPTION
This is a required field, so should be in the example