### PR TITLE
fix!: remove sentry_dsn variable

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -106,9 +106,6 @@ locals {
     STITCH_API_TOKEN = var.stitch_api_token_secretsmanager_arn
   }
 
-  sentry_dsn_environment_variable = var.sentry_dsn != "" ? {
-    SENTRY_DSN = var.sentry_dsn
-  } : {}
   sentry_event_level_env_variable = var.sentry_event_level != "" ? {
     SENTRY_EVENT_LEVEL = var.sentry_event_level
   } : {}

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1539,7 +1539,6 @@ module "monocle" {
       TIMEOUT                    = "900"
       DATAWATCH_ADDRESS          = "https://${local.datawatch_dns_name}"
     },
-    local.sentry_dsn_environment_variable,
     local.sentry_event_level_env_variable,
     var.datadog_agent_enabled ? {
       DD_PROFILING_ENABLED     = "true"
@@ -1639,7 +1638,6 @@ module "toretto" {
       TIMEOUT                    = "900"
       DATAWATCH_ADDRESS          = "https://${local.datawatch_dns_name}"
     },
-    local.sentry_dsn_environment_variable,
     local.sentry_event_level_env_variable,
   )
 
@@ -1724,7 +1722,6 @@ module "scheduler" {
       REDIS_PRIMARY_ADDRESS = module.redis.primary_endpoint_dns_name
       REDIS_PRIMARY_PORT    = module.redis.port
     },
-    local.sentry_dsn_environment_variable,
   )
 
   secret_arns = merge(
@@ -2087,7 +2084,6 @@ module "datawatch" {
 
   environment_variables = merge(
     local.datawatch_dd_env_vars,
-    local.sentry_dsn_environment_variable,
     var.datawatch_additional_environment_vars,
     {
       ENVIRONMENT                     = var.environment
@@ -2186,7 +2182,6 @@ module "datawork" {
 
   environment_variables = merge(
     local.datawatch_dd_env_vars,
-    local.sentry_dsn_environment_variable,
     var.datawork_additional_environment_vars,
     {
       ENVIRONMENT                  = var.environment
@@ -2287,7 +2282,6 @@ module "metricwork" {
 
   environment_variables = merge(
     local.datawatch_dd_env_vars,
-    local.sentry_dsn_environment_variable,
     var.metricwork_additional_environment_vars,
     {
       ENVIRONMENT                  = var.environment

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -336,14 +336,6 @@ variable "acm_certificate_arn" {
 #======================================================
 # Application Variables - General
 #======================================================
-
-# Deprecated - use sentry_dsn_secret_arn
-variable "sentry_dsn" {
-  description = ""
-  type        = string
-  default     = ""
-}
-
 variable "sentry_event_level" {
   description = "The event level for sentry"
   type        = string


### PR DESCRIPTION
This was a sensitive variable that wasn't marked sensitive.

BREAKING CHANGE: The `sentry_dsn` variable was removed

Recommendation: Use the `sentry_dsn_secret_arn` variable, passing the ARN to an AWS SecretsManager secret.

Downtime: No

Steps: Store your Sentry DSN in an AWS SecretsManager secret, delete the `sentry_dsn` terraform variable, and use the `sentry_dsn_secret_arn` variable instead.