### PR TITLE
feat: allow separate optional tags for primary vs replica dbs

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1005,6 +1005,8 @@ module "temporal_rds" {
   create_option_group                   = false
   create_parameter_group                = false
   tags                                  = merge(local.tags, var.temporal_rds_additional_tags)
+  primary_additional_tags               = var.temporal_rds_primary_additional_tags
+  replica_additional_tags               = var.temporal_rds_primary_additional_tags
 }
 
 resource "aws_security_group" "temporal_lb" {
@@ -2009,7 +2011,9 @@ module "datawatch_rds" {
   replica_instance_class          = var.datawatch_rds_replica_instance_type
   replica_backup_retention_period = var.datawatch_rds_replica_backup_retention_period
 
-  tags = merge(local.tags, var.datawatch_rds_additional_tags)
+  tags                    = merge(local.tags, var.datawatch_rds_additional_tags)
+  primary_additional_tags = var.datawatch_rds_primary_additional_tags
+  replica_additional_tags = var.datawatch_rds_replica_additional_tags
 }
 
 #======================================================

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -782,6 +782,18 @@ variable "temporal_rds_additional_tags" {
   default     = {}
 }
 
+variable "temporal_rds_primary_additional_tags" {
+  description = "Additional tags to apply to the temporal RDS primary DB.  This is merged with temporal_rds_additional_tags for the primary"
+  type        = map(string)
+  default     = {}
+}
+
+variable "temporal_rds_replica_additional_tags" {
+  description = "Additional tags to apply to the temporal RDS replica DB.  This is merged with temporal_rds_additional_tags for the replica"
+  type        = map(string)
+  default     = {}
+}
+
 variable "temporal_desired_count" {
   description = "The desired number of replicas"
   type        = number
@@ -967,6 +979,18 @@ variable "datawatch_rds_extra_security_group_ids" {
 
 variable "datawatch_rds_additional_tags" {
   description = "Additional tags to apply to the datawatch RDS resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "datawatch_rds_primary_additional_tags" {
+  description = "Additional tags to apply to the datawatch RDS primary DB.  This is merged with datawatch_rds_additional_tags for the primary"
+  type        = map(string)
+  default     = {}
+}
+
+variable "datawatch_rds_replica_additional_tags" {
+  description = "Additional tags to apply to the datawatch RDS replica DB.  This is merged with datawatch_rds_additional_tags for the replica"
   type        = map(string)
   default     = {}
 }

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -148,7 +148,7 @@ module "this" {
   parameter_group_description = "Bigeye RDS parameter group with recommendations"
   parameters                  = var.parameters
 
-  tags = var.tags
+  tags = merge(var.tags, var.primary_additional_tags)
 }
 
 module "replica" {
@@ -194,6 +194,6 @@ module "replica" {
   create_db_option_group    = false
   option_group_name         = module.this.db_option_group_id
 
-  tags = var.tags
+  tags = merge(var.tags, var.replica_additional_tags)
 }
 

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -210,7 +210,19 @@ variable "vpc_id" {
 }
 
 variable "tags" {
-  description = "A list of tags to apply to the RDS resources"
+  description = "A list of tags to apply to RDS resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "primary_additional_tags" {
+  description = "A list of tags to apply to the RDS primary DB.  This is merged with var.tags for the primary db"
+  type        = map(string)
+  default     = {}
+}
+
+variable "replica_additional_tags" {
+  description = "Tags to apply to the RDS replica DB (if a replica is enabled).  This is merged with var.tags for the replica"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
It's useful to be able to tag the primary and replica DB's with different tags.