### PR TITLE
fix: bump GH slack actions version

### DIFF
--- a/.github/workflows/test_and_publish.yaml
+++ b/.github/workflows/test_and_publish.yaml
@@ -133,7 +133,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BIGEYE_SRE_BOT_GH_PAT }}
       - name: notify slack
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v1.25.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
         with:


### PR DESCRIPTION
This updates the runtime to node 20 so we don't get the node 16 warnings on GH action runs.