### PR TITLE
Make the 4 email server params configurable

### DIFF
--- a/examples/self-managed-mail-server/README.md
+++ b/examples/self-managed-mail-server/README.md
@@ -1,0 +1,21 @@
+# Self-Managed Mail Server
+
+Some installation environments may require using a custom SMTP server to relay
+Bigeye email notifications instead of the default Bigeye SMTP server.  Installs
+where no internet-access is allowed is a common use case for this.
+
+## Prerequisites
+
+You will need all the same prerequisites as the standard
+install as well as your custom SMTP server connection info.
+
+Also create an AWS secrets manager secret and put the password for your SMTP credential as a string.
+
+## Configuration
+
+* `byomailserver_smtp_host` - hostname of your custom SMTP server
+* `byomailserver_smtp_port` - port of your custom SMTP server
+* `byomailserver_smtp_user` - username for your custom SMTP server
+* `byomailserver_smtp_password_secret_arn` - AWS secrets manager ARN containing the password for your custom SMTP server.  See [main.tf](./main.tf) for implementation
+
+A sample configuration can be found in [main.tf](./main.tf)

--- a/examples/self-managed-mail-server/main.tf
+++ b/examples/self-managed-mail-server/main.tf
@@ -1,0 +1,22 @@
+data "aws_secretsmanager_secret" "byomailserver_smtp_password" {
+  name = "bigeye/example/byomailserver-smtp-password"
+}
+
+module "bigeye" {
+  source      = "git::https://github.com/bigeyedata/terraform-modules//modules/bigeye?ref=v2.4.0"
+  environment = "test"
+  instance    = "bigeye"
+
+  # Your parent DNS name here, e.g. bigeye.my-company.com
+  top_level_dns_name = ""
+
+  # Get this from Bigeye Sales
+  image_tag = ""
+
+  # byo mail server
+  byomailserver_smtp_host                = "smtp.example.com"
+  byomailserver_smtp_port                = "587"
+  byomailserver_smtp_user                = "smtp.user@mail.example.com"
+  byomailserver_smtp_password_secret_arn = data.aws_secretsmanager_secret.byomailserver_smtp_password.arn
+}
+

--- a/examples/self-managed-vpc-no-internet-access/README.md
+++ b/examples/self-managed-vpc-no-internet-access/README.md
@@ -20,6 +20,8 @@ See the "Standard" example for more details on general Bigeye stack configuratio
 You will need all the same prerequisites as the standard
 install, as well as an existing VPC with appropriate subnets.
 
+Also create an AWS secrets manager secret and put the password for your SMTP credential as a string.
+
 ## Configuration
 
 Follow all the configuration steps in the standard install,
@@ -36,6 +38,10 @@ and then add the following variables:
 * `internet_facing          = false` - do not create the API/UI LB as public facing
 * `create_security_groups = false` - do not create security groups for the various services.  This allows you to bring your own with inbound cidr ranges restricted.  While technically not required since the subnets do not have a route to public net, this is a 2nd layer of security to ensure no public inbound traffic is allowed to the Bigeye application.  You will likely want to add your VPN cidr range to this anyhow.
 * `*_extra_security_group_ids` - use your own security groups for resources (see create_security_groups = false)
+* `byomailserver_smtp_host` - hostname of your custom SMTP server
+* `byomailserver_smtp_port` - port of your custom SMTP server
+* `byomailserver_smtp_user` - username for your custom SMTP server
+* `byomailserver_smtp_password_secret_arn` - AWS secrets manager ARN containing the password for your custom SMTP server.  See [main.tf](./main.tf) for implementation
 
 Your VPC structure will dictate which subnet IDs need to be
 chosen for each category here. You must provide at least two

--- a/examples/self-managed-vpc-no-internet-access/main.tf
+++ b/examples/self-managed-vpc-no-internet-access/main.tf
@@ -1,6 +1,14 @@
 locals {
-  environment = "test"
-  instance    = "no-igw"
+  environment                                               = "test"
+  instance                                                  = "no-igw"
+  byomailserver_smtp_password_aws_secrets_manager_secret_id = "bigeye/example/byomailserver-smtp-password"
+  byomailserver_smtp_host                                   = "smtp.example.com"
+  byomailserver_smtp_port                                   = "587"
+  byomailserver_smtp_user                                   = "smtp.user@mail.example.com"
+}
+
+data "aws_secretsmanager_secret" "byomailserver_smtp_password" {
+  name = local.byomailserver_smtp_password_aws_secrets_manager_secret_id
 }
 
 module "bigeye" {
@@ -57,4 +65,11 @@ module "bigeye" {
 
   temporal_internet_facing = false
   internet_facing          = false
+
+  # byo mail server.  Bigeye's default SMTP server will not be reachable to route email notifications
+  # in a no-igw setup so add this for no-igw installs.  This can be omitted if you do not wish to receive email notifications.
+  byomailserver_smtp_host                = local.byomailserver_smtp_host
+  byomailserver_smtp_port                = local.byomailserver_smtp_port
+  byomailserver_smtp_user                = local.byomailserver_smtp_user
+  byomailserver_smtp_password_secret_arn = data.aws_secretsmanager_secret.byomailserver_smtp_password.arn
 }

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -115,7 +115,7 @@ locals {
   sentry_event_level_env_variable = var.sentry_event_level != "" ? {
     SENTRY_EVENT_LEVEL = var.sentry_event_level
   } : {}
-  sentry_dsn_secret_arn = var.sentry_dsn_secret_arn != "" ? {
+  sentry_dsn_secret_map = var.sentry_dsn_secret_arn != "" ? {
     SENTRY_DSN = var.sentry_dsn_secret_arn
   } : {}
 
@@ -129,7 +129,7 @@ locals {
     local.auth0_secrets_map,
     local.slack_secrets_map,
     local.stitch_secrets_map,
-    local.sentry_dsn_secret_arn,
+    local.sentry_dsn_secret_map,
     local.byomailserver_smtp_password_secrets_map,
     var.datawatch_additional_secret_arns,
     {

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -50,6 +50,12 @@ locals {
   temporal_rds_password_secret_arn     = local.create_temporal_rds_password_secret ? aws_secretsmanager_secret.temporal_rds_password[0].arn : var.temporal_rds_root_user_password_secret_arn
   create_adminpages_password_secret    = var.adminpages_password_secret_arn == ""
   adminpages_password_secret_arn       = local.create_adminpages_password_secret ? aws_secretsmanager_secret.adminpages_password[0].arn : var.adminpages_password_secret_arn
+  # byomailserver
+  byomailserver_enabled                   = var.byomailserver_smtp_host != "" && var.byomailserver_smtp_port != "" && var.byomailserver_smtp_user != "" && var.byomailserver_smtp_password_secret_arn != ""
+  byomailserver_smtp_host                 = local.byomailserver_enabled ? var.byomailserver_smtp_host : ""
+  byomailserver_smtp_port                 = local.byomailserver_enabled ? var.byomailserver_smtp_port : ""
+  byomailserver_smtp_user                 = local.byomailserver_enabled ? var.byomailserver_smtp_user : ""
+  byomailserver_smtp_password_secrets_map = local.byomailserver_enabled ? { MAILER_PASSWORD = var.byomailserver_smtp_password_secret_arn } : {}
 
   # DNS
   base_dns_alias                          = coalesce(var.vanity_alias, local.name)
@@ -124,6 +130,7 @@ locals {
     local.slack_secrets_map,
     local.stitch_secrets_map,
     local.sentry_dsn_secret_arn,
+    local.byomailserver_smtp_password_secrets_map,
     var.datawatch_additional_secret_arns,
     {
       REDIS_PRIMARY_PASSWORD = local.redis_auth_token_secret_arn
@@ -142,6 +149,7 @@ locals {
   temporal_worker_persistence_max_qps                  = var.temporal_worker_persistence_max_qps
   temporal_system_visibility_persistence_max_read_qps  = var.temporal_system_visibility_persistence_max_read_qps
   temporal_system_visibility_persistence_max_write_qps = var.temporal_system_visibility_persistence_max_write_qps
+
 
   #======================================================
   # Datadog specs

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1551,7 +1551,7 @@ module "monocle" {
 
   secret_arns = merge(
     var.monocle_additional_secret_arns,
-    local.sentry_dsn_secret_arn,
+    local.sentry_dsn_secret_map,
     local.stitch_secrets_map,
     {
       MQ_BROKER_PASSWORD = local.rabbitmq_user_password_secret_arn
@@ -1642,7 +1642,7 @@ module "toretto" {
 
   secret_arns = merge(
     var.toretto_additional_secret_arns,
-    local.sentry_dsn_secret_arn,
+    local.sentry_dsn_secret_map,
     local.stitch_secrets_map,
     {
       MQ_BROKER_PASSWORD = local.rabbitmq_user_password_secret_arn
@@ -1800,7 +1800,7 @@ module "scheduler" {
       REDIS_PRIMARY_PASSWORD = local.redis_auth_token_secret_arn
       ROBOT_PASSWORD         = local.robot_password_secret_arn
     },
-    local.sentry_dsn_secret_arn,
+    local.sentry_dsn_secret_map,
   )
 }
 

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2202,6 +2202,10 @@ module "datawatch" {
       TEMPORAL_NAMESPACE                         = var.temporal_namespace
       TEMPORAL_SSL_HOSTNAME_VERIFICATION_ENABLED = var.temporal_use_default_certificates ? "false" : "true"
 
+      MAILER_HOST = local.byomailserver_smtp_host
+      MAILER_PORT = local.byomailserver_smtp_port
+      MAILER_USER = local.byomailserver_smtp_user
+
       MTLS_KEY_PATH      = "/temporal/mtls.key"
       MTLS_CERT_PATH     = "/temporal/mtls.pem"
       MAX_RAM_PERCENTAGE = var.datawatch_jvm_max_ram_pct
@@ -2304,10 +2308,15 @@ module "datawork" {
       TEMPORAL_TARGET                            = "${local.temporal_dns_name}:${local.temporal_lb_port}"
       TEMPORAL_NAMESPACE                         = var.temporal_namespace
       TEMPORAL_SSL_HOSTNAME_VERIFICATION_ENABLED = var.temporal_use_default_certificates ? "false" : "true"
-      MTLS_KEY_PATH                              = "/temporal/mtls.key"
-      MTLS_CERT_PATH                             = "/temporal/mtls.pem"
-      MAX_RAM_PERCENTAGE                         = var.datawatch_jvm_max_ram_pct
-      AWS_REGION                                 = local.aws_region
+
+      MAILER_HOST = local.byomailserver_smtp_host
+      MAILER_PORT = local.byomailserver_smtp_port
+      MAILER_USER = local.byomailserver_smtp_user
+
+      MTLS_KEY_PATH      = "/temporal/mtls.key"
+      MTLS_CERT_PATH     = "/temporal/mtls.pem"
+      MAX_RAM_PERCENTAGE = var.datawatch_jvm_max_ram_pct
+      AWS_REGION         = local.aws_region
     }
   )
 
@@ -2405,10 +2414,15 @@ module "metricwork" {
       TEMPORAL_TARGET                            = "${local.temporal_dns_name}:${local.temporal_lb_port}"
       TEMPORAL_NAMESPACE                         = var.temporal_namespace
       TEMPORAL_SSL_HOSTNAME_VERIFICATION_ENABLED = var.temporal_use_default_certificates ? "false" : "true"
-      MTLS_KEY_PATH                              = "/temporal/mtls.key"
-      MTLS_CERT_PATH                             = "/temporal/mtls.pem"
-      MAX_RAM_PERCENTAGE                         = var.datawatch_jvm_max_ram_pct
-      AWS_REGION                                 = local.aws_region
+
+      MAILER_HOST = local.byomailserver_smtp_host
+      MAILER_PORT = local.byomailserver_smtp_port
+      MAILER_USER = local.byomailserver_smtp_user
+
+      MTLS_KEY_PATH      = "/temporal/mtls.key"
+      MTLS_CERT_PATH     = "/temporal/mtls.pem"
+      MAX_RAM_PERCENTAGE = var.datawatch_jvm_max_ram_pct
+      AWS_REGION         = local.aws_region
     }
   )
 

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -394,6 +394,31 @@ variable "stitch_api_token_secretsmanager_arn" {
   default     = ""
 }
 
+variable "byomailserver_smtp_host" {
+  description = "Hostname of SMTP server.  This is for routing email notifications through your customer SMTP server vs using Bigeye's.  Ex. smtp.example.com"
+  type        = string
+  default     = ""
+}
+
+variable "byomailserver_smtp_port" {
+  description = "Port for the SMTP server.  This is for routing email notifications through your customer SMTP server vs using Bigeye's."
+  type        = string
+  default     = ""
+}
+
+variable "byomailserver_smtp_user" {
+  description = "SMTP credentials for your custom SMPT server."
+  type        = string
+  default     = ""
+}
+
+variable "byomailserver_smtp_password_secret_arn" {
+  description = "secrets manager ARN for the SMTP password."
+  type        = string
+  default     = ""
+}
+
+
 #======================================================
 # Application Variables - Monocle
 #======================================================


### PR DESCRIPTION
commit da39491e3063ece27557b7dd429571a488953191 (HEAD -> matthalverson/one-1339-code-change-make-the-4-email-server-params-configurable, origin/matthalverson/one-1339-code-change-make-the-4-email-server-params-configurable)
Author: David Nguyen <david@bigeye.com>
Date:   Thu Feb 15 18:34:38 2024 -0800

    docs: add documentation for byo mail server

commit d90425a9a706e27ab7a4900672b8425913db9d38
Author: David Nguyen <david@bigeye.com>
Date:   Thu Feb 15 18:12:45 2024 -0800

    feat: add BYO mail server env vars to datawatch, datawork, metricwork

    These vars are for plumbing in a custom SMTP server.  The app is
    set up to fall back to default for both empty string env vars
    and non-existant env vars.

    I opted to only enable the feature if all 4 required env vars are
    specified to avoid any kind of mistakes when trying to use the feature