### PR TITLE
feat: add ability to set ingress cidr blocks for rabbitmq

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -681,15 +681,16 @@ module "rabbitmq" {
   deployment_mode        = var.redundant_infrastructure ? "CLUSTER_MULTI_AZ" : "SINGLE_INSTANCE"
   create_security_groups = var.create_security_groups
   # TODO add module.bigeye_admin.client_security_group_id to the list of extra_security_groups when AWS MQ supports modifying security groups
-  extra_security_groups    = var.rabbitmq_extra_security_group_ids
-  subnet_ids               = local.rabbitmq_subnet_group_ids
-  instance_type            = var.rabbitmq_instance_type
-  engine_version           = var.rabbitmq_engine_version
-  maintenance_day          = var.rabbitmq_maintenance_day
-  maintenance_time         = var.rabbitmq_maintenance_time
-  user_name                = var.rabbitmq_user_name
-  user_password_secret_arn = local.rabbitmq_user_password_secret_arn
-  tags                     = local.tags
+  extra_security_groups     = var.rabbitmq_extra_security_group_ids
+  extra_ingress_cidr_blocks = var.rabbitmq_extra_ingress_cidr_blocks
+  subnet_ids                = local.rabbitmq_subnet_group_ids
+  instance_type             = var.rabbitmq_instance_type
+  engine_version            = var.rabbitmq_engine_version
+  maintenance_day           = var.rabbitmq_maintenance_day
+  maintenance_time          = var.rabbitmq_maintenance_time
+  user_name                 = var.rabbitmq_user_name
+  user_password_secret_arn  = local.rabbitmq_user_password_secret_arn
+  tags                      = local.tags
 }
 
 #======================================================

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -281,10 +281,17 @@ variable "rabbitmq_user_password_secret_arn" {
 }
 
 variable "rabbitmq_extra_security_group_ids" {
-  description = "A list of additional security group IDs to apply to the RabbitMQ broker"
+  description = "A list of additional security group IDs to apply to the RabbitMQ broker.  See also rabbitmq_extra_ingress_cidr_blocks"
   type        = list(string)
   default     = []
 }
+
+variable "rabbitmq_extra_ingress_cidr_blocks" {
+  description = "A list of additional ingress cidrs to allow access to both the AMQPS port and the HTTPS admin port.  This is necessary to use in cases where it is required to grant access to RabbitMQ externally as AWS MQ does not allow modifying security groups after MQ creation."
+  type        = list(string)
+  default     = []
+}
+
 
 variable "rabbitmq_instance_type" {
   description = "The instance type of the RabbitMQ broker"

--- a/modules/rabbitmq/main.tf
+++ b/modules/rabbitmq/main.tf
@@ -66,10 +66,27 @@ resource "aws_security_group" "this" {
   vpc_id = var.vpc_id
 
   ingress {
+    description     = "AMPQS connections from Bigeye"
     from_port       = 5671
     to_port         = 5671
     protocol        = "TCP"
     security_groups = [aws_security_group.client[0].id]
+  }
+
+  ingress {
+    description = "AMPQS connections from custom cidr blocks"
+    from_port   = 5671
+    to_port     = 5671
+    protocol    = "TCP"
+    cidr_blocks = var.extra_ingress_cidr_blocks
+  }
+
+  ingress {
+    description = "RabbitMQ admin console from custom cidr blocks"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = var.extra_ingress_cidr_blocks
   }
 
   tags = merge(var.tags, {

--- a/modules/rabbitmq/variables.tf
+++ b/modules/rabbitmq/variables.tf
@@ -20,6 +20,12 @@ variable "extra_security_groups" {
   default     = []
 }
 
+variable "extra_ingress_cidr_blocks" {
+  description = "A list of additional ingress cidrs to allow access to both the AMQPS port and the HTTPS admin port.  This is necessary to use in cases where it is required to grant access to RabbitMQ externally as AWS MQ does not allow modifying security groups after MQ creation."
+  type        = list(string)
+  default     = []
+}
+
 variable "subnet_ids" {
   description = "List of subnet ids for the RabbitMQ Broker to run in"
   type        = list(string)


### PR DESCRIPTION
The usual method of allowing attachment of additional security groups to grant access does not work for Amazon MQ after MQ creation.  To side step this and still allow addtional access to Rabbit's AMQPS and HTTPS admin console, this PR allows passing in extra cidr blocks directly.