### PR TITLE
Allow access to rabbit mq admin page https for tf stacks

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -674,14 +674,13 @@ resource "aws_secretsmanager_secret_version" "rabbitmq_user_password" {
 }
 
 module "rabbitmq" {
-  depends_on             = [aws_secretsmanager_secret_version.rabbitmq_user_password]
-  source                 = "../rabbitmq"
-  name                   = local.name
-  vpc_id                 = local.vpc_id
-  deployment_mode        = local.rabbitmq_cluster_mode_enabled ? "CLUSTER_MULTI_AZ" : "SINGLE_INSTANCE"
-  create_security_groups = var.create_security_groups
-  # TODO add module.bigeye_admin.client_security_group_id to the list of extra_security_groups when AWS MQ supports modifying security groups
-  extra_security_groups     = var.rabbitmq_extra_security_group_ids
+  depends_on                = [aws_secretsmanager_secret_version.rabbitmq_user_password]
+  source                    = "../rabbitmq"
+  name                      = local.name
+  vpc_id                    = local.vpc_id
+  deployment_mode           = local.rabbitmq_cluster_mode_enabled ? "CLUSTER_MULTI_AZ" : "SINGLE_INSTANCE"
+  create_security_groups    = var.create_security_groups
+  extra_security_groups     = concat(var.rabbitmq_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   extra_ingress_cidr_blocks = var.rabbitmq_extra_ingress_cidr_blocks
   subnet_ids                = local.rabbitmq_subnet_group_ids
   instance_type             = var.rabbitmq_instance_type


### PR DESCRIPTION
commit 5b2ee9a4670990cf3a745d21d44beeb832130562 (HEAD -> david/sre-2840-allow-access-to-rabbit-mq-admin-page-https-for-tf-stacks, origin/david/sre-2840-allow-access-to-rabbit-mq-admin-page-https-for-tf-stacks)
Author: David Nguyen <david@bigeye.com>
Date:   Thu Feb 22 16:51:50 2024 -0800

    feat: allow admin container access to RabbitMQ

    BREAKING CHANGE: This requires manual deletion of the <stack>-rabbitmq
    instance.

    AWS managed RabbitMQ does not allow changing security group membership
    for RabbitMQ so the resource must be deleted manually first before
    we can allow the admin container access to RabbitMQ.

commit 728e0b582b33e96450747fb1bb8a55fc01776628
Author: David Nguyen <david@bigeye.com>
Date:   Thu Feb 22 16:43:26 2024 -0800

    fix: use dedicated ingress rule for rabbitmq security group

    BREAKING CHANGE: This requires users to remove all existing
    security group rules from the <stack>-rabbitmq security group.

    The terraform run will fail due to duplicate ingress rules otherwise.

    This change was required to avoid terraform perpetually detecting
    changes when rabbitmq_extra_cidr_blocks is an empty list (default).