### PR TITLE
fix: only create ingress rule if create_security_groups = true

### DIFF
--- a/modules/rabbitmq/main.tf
+++ b/modules/rabbitmq/main.tf
@@ -68,6 +68,7 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "amqps_bigeye" {
+  count                        = var.create_security_groups ? 1 : 0
   description                  = "AMPQS connections from Bigeye"
   security_group_id            = aws_security_group.this[0].id
   from_port                    = 5671


### PR DESCRIPTION
When create_security_groups = false, rabbitmq security group creation is failing.  This bug was introduced in 3.0.0 https://github.com/bigeyedata/terraform-modules/pull/141