### PR TITLE
docs: update examples to have a consistent image_tag and registry

### DIFF
--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -6,7 +6,11 @@ module "bigeye" {
   # Your parent DNS name here, e.g. bigeye.my-company.com
   top_level_dns_name = ""
 
-  # Get this from Bigeye Sales
+  # This is Bigeye's ECR registry.  Setting this to Bigeye's registry is simple as a hello world example, but it is recommended
+  # for enterprise customers to cache our images in you own ECR repo.  See the self-managed-ecr example
+  image_registry = "021451147547.dkr.ecr.us-west-2.amazonaws.com"
+
+  # Bigeye app version.  You can list the tags available in the image_registry (using the latest is always recommended).
   image_tag = ""
 }
 

--- a/examples/self-managed-dns/main.tf
+++ b/examples/self-managed-dns/main.tf
@@ -14,7 +14,12 @@ module "bigeye" {
   create_dns_records  = false
   acm_certificate_arn = local.acm_certificate_arn
 
-  image_tag = "1.35.0"
+  # This is Bigeye's ECR registry.  Setting this to Bigeye's registry is simple as a hello world example, but it is recommended
+  # for enterprise customers to cache our images in you own ECR repo.  See the self-managed-ecr example
+  image_registry = "021451147547.dkr.ecr.us-west-2.amazonaws.com"
+
+  # Bigeye app version.  You can list the tags available in the image_registry (using the latest is always recommended).
+  image_tag = ""
 }
 
 output "bigeye" {

--- a/examples/self-managed-ecr/main.tf
+++ b/examples/self-managed-ecr/main.tf
@@ -7,7 +7,8 @@ module "bigeye" {
   top_level_dns_name = ""
 
   image_registry = format("%s.dkr.ecr.us-west-2.amazonaws.com", aws_ecr_repository.bigeye_ecr[0].registry_id)
-  # Get this from Bigeye Sales
+
+  # Bigeye app version.  You can list the tags available in the image_registry (using the latest is always recommended).
   image_tag = ""
 }
 

--- a/examples/self-managed-mail-server/main.tf
+++ b/examples/self-managed-mail-server/main.tf
@@ -10,7 +10,11 @@ module "bigeye" {
   # Your parent DNS name here, e.g. bigeye.my-company.com
   top_level_dns_name = ""
 
-  # Get this from Bigeye Sales
+  # This is Bigeye's ECR registry.  Setting this to Bigeye's registry is simple as a hello world example, but it is recommended
+  # for enterprise customers to cache our images in you own ECR repo.  See the self-managed-ecr example
+  image_registry = "021451147547.dkr.ecr.us-west-2.amazonaws.com"
+
+  # Bigeye app version.  You can list the tags available in the image_registry (using the latest is always recommended).
   image_tag = ""
 
   # byo mail server

--- a/examples/self-managed-mtls-certs/main.tf
+++ b/examples/self-managed-mtls-certs/main.tf
@@ -23,8 +23,12 @@ module "bigeye" {
   # in that domain for the application.
   top_level_dns_name = "example.com"
 
+  # This is Bigeye's ECR registry.  Setting this to Bigeye's registry is simple as a hello world example, but it is recommended
+  # for enterprise customers to cache our images in you own ECR repo.  See the self-managed-ecr example
+  image_registry = "021451147547.dkr.ecr.us-west-2.amazonaws.com"
+
   # Bigeye app version.  You can list the tags available in the image_registry (using the latest is always recommended).
-  image_tag = "1.35.0"
+  image_tag = ""
 
   temporal_use_default_certificates = false
 

--- a/examples/self-managed-vpc-no-internet-access/main.tf
+++ b/examples/self-managed-vpc-no-internet-access/main.tf
@@ -18,7 +18,12 @@ module "bigeye" {
 
   # Your parent DNS name here, e.g. bigeye.my-company.com
   top_level_dns_name = ""
-  # Get this from Bigeye Sales
+
+  # This is Bigeye's ECR registry.  Setting this to Bigeye's registry is simple as a hello world example, but it is recommended
+  # for enterprise customers to cache our images in you own ECR repo.  See the self-managed-ecr example
+  image_registry = "021451147547.dkr.ecr.us-west-2.amazonaws.com"
+
+  # Bigeye app version.  You can list the tags available in the image_registry (using the latest is always recommended).
   image_tag = ""
 
   # BYO VPC

--- a/examples/self-managed-vpc/main.tf
+++ b/examples/self-managed-vpc/main.tf
@@ -6,7 +6,11 @@ module "bigeye" {
   # Your parent DNS name here, e.g. bigeye.my-company.com
   top_level_dns_name = ""
 
-  # Get this from Bigeye Sales
+  # This is Bigeye's ECR registry.  Setting this to Bigeye's registry is simple as a hello world example, but it is recommended
+  # for enterprise customers to cache our images in you own ECR repo.  See the self-managed-ecr example
+  image_registry = "021451147547.dkr.ecr.us-west-2.amazonaws.com"
+
+  # Bigeye app version.  You can list the tags available in the image_registry (using the latest is always recommended).
   image_tag = ""
 
   # BYOVPC


### PR DESCRIPTION
The default image_registry pointing at Bigeye's registry should be part of all examples so there are fewer things for first time installers to handle to get installed.