### PR TITLE
fix: always ACM cert creation flag logic

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -79,7 +79,7 @@ locals {
   datawatch_mysql_dns_name = local.use_rds_vanity_names ? local.datawatch_mysql_vanity_dns_name : module.datawatch_rds.primary_dns_name
   temporal_mysql_dns_name  = local.use_rds_vanity_names ? local.temporal_mysql_vanity_dns_name : module.temporal_rds.primary_dns_name
 
-  create_acm_cert           = var.acm_certificate_arn == "" && var.create_dns_records == false ? true : false
+  create_acm_cert           = var.acm_certificate_arn == "" ? true : false
   domain_validation_options = local.create_acm_cert ? aws_acm_certificate.wildcard[0].domain_validation_options : []
   acm_certificate_arn       = local.create_acm_cert ? aws_acm_certificate.wildcard[0].arn : var.acm_certificate_arn
 


### PR DESCRIPTION
The logic should be:

Always create the ACM cert if it isn't passed in.

So it shouldn't rely on DNS control at all since Bigeye requires an ACM cert for SSL on the LBs as we want to enforce HTTPS every where.

Right now the logic does not cover the case where nothing is set (ie all defaults) which is a bug introduced in 1.14.0