### PR TITLE
feat: add variable to control from email for byo smtp server setups

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -52,10 +52,11 @@ locals {
   create_adminpages_password_secret    = var.adminpages_password_secret_arn == ""
   adminpages_password_secret_arn       = local.create_adminpages_password_secret ? aws_secretsmanager_secret.adminpages_password[0].arn : var.adminpages_password_secret_arn
   # byomailserver
-  byomailserver_enabled                   = var.byomailserver_smtp_host != "" && var.byomailserver_smtp_port != "" && var.byomailserver_smtp_user != "" && var.byomailserver_smtp_password_secret_arn != ""
+  byomailserver_enabled                   = var.byomailserver_smtp_host != "" && var.byomailserver_smtp_port != "" && var.byomailserver_smtp_user != "" && var.byomailserver_smtp_password_secret_arn != "" && var.byomailserver_smtp_from_address != ""
   byomailserver_smtp_host                 = local.byomailserver_enabled ? var.byomailserver_smtp_host : ""
   byomailserver_smtp_port                 = local.byomailserver_enabled ? var.byomailserver_smtp_port : ""
   byomailserver_smtp_user                 = local.byomailserver_enabled ? var.byomailserver_smtp_user : ""
+  byomailserver_smtp_from_address         = local.byomailserver_enabled ? var.byomailserver_smtp_from_address : ""
   byomailserver_smtp_password_secrets_map = local.byomailserver_enabled ? { MAILER_PASSWORD = var.byomailserver_smtp_password_secret_arn } : {}
 
   # DNS

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2282,9 +2282,10 @@ module "datawatch" {
       TEMPORAL_NAMESPACE                         = var.temporal_namespace
       TEMPORAL_SSL_HOSTNAME_VERIFICATION_ENABLED = var.temporal_use_default_certificates ? "false" : "true"
 
-      MAILER_HOST = local.byomailserver_smtp_host
-      MAILER_PORT = local.byomailserver_smtp_port
-      MAILER_USER = local.byomailserver_smtp_user
+      MAILER_HOST         = local.byomailserver_smtp_host
+      MAILER_PORT         = local.byomailserver_smtp_port
+      MAILER_USER         = local.byomailserver_smtp_user
+      MAILER_FROM_ADDRESS = local.byomailserver_smtp_from_address
 
       MTLS_KEY_PATH      = "/temporal/mtls.key"
       MTLS_CERT_PATH     = "/temporal/mtls.pem"
@@ -2389,9 +2390,10 @@ module "datawork" {
       TEMPORAL_NAMESPACE                         = var.temporal_namespace
       TEMPORAL_SSL_HOSTNAME_VERIFICATION_ENABLED = var.temporal_use_default_certificates ? "false" : "true"
 
-      MAILER_HOST = local.byomailserver_smtp_host
-      MAILER_PORT = local.byomailserver_smtp_port
-      MAILER_USER = local.byomailserver_smtp_user
+      MAILER_HOST         = local.byomailserver_smtp_host
+      MAILER_PORT         = local.byomailserver_smtp_port
+      MAILER_USER         = local.byomailserver_smtp_user
+      MAILER_FROM_ADDRESS = local.byomailserver_smtp_from_address
 
       MTLS_KEY_PATH      = "/temporal/mtls.key"
       MTLS_CERT_PATH     = "/temporal/mtls.pem"
@@ -2495,9 +2497,10 @@ module "metricwork" {
       TEMPORAL_NAMESPACE                         = var.temporal_namespace
       TEMPORAL_SSL_HOSTNAME_VERIFICATION_ENABLED = var.temporal_use_default_certificates ? "false" : "true"
 
-      MAILER_HOST = local.byomailserver_smtp_host
-      MAILER_PORT = local.byomailserver_smtp_port
-      MAILER_USER = local.byomailserver_smtp_user
+      MAILER_HOST         = local.byomailserver_smtp_host
+      MAILER_PORT         = local.byomailserver_smtp_port
+      MAILER_USER         = local.byomailserver_smtp_user
+      MAILER_FROM_ADDRESS = local.byomailserver_smtp_from_address
 
       MTLS_KEY_PATH      = "/temporal/mtls.key"
       MTLS_CERT_PATH     = "/temporal/mtls.pem"

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -424,12 +424,18 @@ variable "byomailserver_smtp_user" {
   default     = ""
 }
 
+
+variable "byomailserver_smtp_from_address" {
+  description = "Set the from address for email notifications from Bigeye.  This should be from a domain the mail server is verified to be able to send emails as, ie bigeye@example.com."
+  type        = string
+  default     = ""
+}
+
 variable "byomailserver_smtp_password_secret_arn" {
   description = "secrets manager ARN for the SMTP password."
   type        = string
   default     = ""
 }
-
 
 #======================================================
 # Application Variables - Monocle


### PR DESCRIPTION
    For installs where a custom SMTP server is being used, we want to
    require setting the "from address" to a domain that the installer
    controls, ie the mail server is verified to send for (dkim, spf, dmarc.)