### PR TITLE
docs: update self-managed-vpc-no-internet-access instructions

### DIFF
--- a/examples/self-managed-vpc-no-internet-access/README.md
+++ b/examples/self-managed-vpc-no-internet-access/README.md
@@ -1,53 +1,221 @@
-# Self-Managed VPC
+# Self-managed VPC with no internet access installation
 
 Some installation environments may require installing Bigeye in a VPC that has no NAT or route for
-any services or resources to public net. The method for doing this is to create your own (or bring 
-an existing) VPC that does not have internet access and pass it into the Bigeye module.  
+any services or resources to public net. The method for doing this is to create your own (or bring
+an existing) VPC that does not have internet access and pass it into the Bigeye module.
 
-This example shows the necessary configuration of variables for the Bigeye module to accomplish 
+The only file necessary to install Bigeye with existing infrastructure (DNS domain, vpc, security groups,
+mail server, etc) is [main.tf](./main.tf).  All of the other `*_example.tf` files are here as
+a reference as they will create example infrastructure (DNS domain, vpc, security groups,
+mail server, etc) for an end to end test.
+
+This example shows the necessary configuration of variables for the Bigeye module to accomplish
 this as well as a sample VPC configuration with the necessary VPC Endpoints (S3, logs, ECR) and
 security groups that can be used as a reference.  The VPC endpoints are required for the services
 to function properly without access to AWS' public service endpoints and is just overall a recommended
 practice, even if your installation will have access to/from public net.
 
-Creating your own security groups allows you to restrict inbound traffic to just your VPC cidr 
+Creating your own security groups allows you to restrict inbound traffic to just your VPC cidr
 which is a 2nd level of security beyond simple removing subnet routes to public net.
 
-See the "Standard" example for more details on general Bigeye stack configuration.
+See the "[Standard](../standard/README.md)" example for more details on general Bigeye stack configuration.
+
+This bigeye module includes everything you need to install a Bigeye stack into your AWS account.
+
+The module includes:
+
+* VPC
+* Security Groups
+* IAM Roles
+* ALBs & ACM SSL cert
+* ECS cluster, services, and tasks
+* Secrets
+* S3 buckets
+* RabbitMQ Broker
+* Elasticache
+
 
 ## Prerequisites
 
-You will need all the same prerequisites as the standard
-install, as well as an existing VPC with appropriate subnets.
+* Install [Terraform](https://github.com/bigeyedata/terraform-modules/blob/main/README.md#prerequisites)
+* Install git
+* Access to an ECR registry with container images (get from Bigeye)
+* An image tag (get from Bigeye)
+* An AWS account with a Route53 Hosted Zone where Terraform will write DNS records
+* AWS credentials (access keys)
+* ssh keys generated (~/.ssh/id_rsa.pub exists)
 
-Also create an AWS secrets manager secret and put the password for your SMTP credential as a string.
+### Terraform install
+Official docs: (https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
 
-## Configuration
+**OSX:** 
+```shell
+brew tap hashicorp/tap
+brew install hashicorp/tap/terraform
+```
 
-Follow all the configuration steps in the standard install,
-and then add the following variables:
+**RHEL Linux:**
+```bash
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
+sudo yum -y install terraform
+```
 
-* `byovpc_vpc_id` - get this from the VPC you're installing within
-* `byovpc_rabbitmq_subnet_ids` - a list of subnet IDs to install the RabbitMQ broker. These do not need internet access.
-* `byovpc_internal_subnet_ids` - a list of subnet IDs to create internal service load balancers. These do not need internet access.
-* `byovpc_application_subnet_ids` - a list of subnet IDs to launch ECS tasks. These should have egress to the internet.
-* `byovpc_public_subnet_ids` - a list of subnet IDs to launch internet-facing load balancers.
-* `byovpc_redis_subnet_group_name` - the name of the subnet group to launch the Redis node(s).
-* `byovpc_database_subnet_group_name` - the name of the subnet group to launch the RDS instances.
-* `temporal_internet_facing = false` - do not create the temporal service LB as public facing
-* `internet_facing          = false` - do not create the API/UI LB as public facing
-* `create_security_groups = false` - do not create security groups for the various services.  This allows you to bring your own with inbound cidr ranges restricted.  While technically not required since the subnets do not have a route to public net, this is a 2nd layer of security to ensure no public inbound traffic is allowed to the Bigeye application.  You will likely want to add your VPN cidr range to this anyhow.
-* `*_extra_security_group_ids` - use your own security groups for resources (see create_security_groups = false)
-* `byomailserver_smtp_host` - hostname of your custom SMTP server
-* `byomailserver_smtp_port` - port of your custom SMTP server
-* `byomailserver_smtp_user` - username for your custom SMTP server
-* `byomailserver_smtp_password_secret_arn` - AWS secrets manager ARN containing the password for your custom SMTP server.  See [main.tf](./main.tf) for implementation
+**Ubuntu/Debian Linux:**
+```shell
+sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
+wget -O- https://apt.releases.hashicorp.com/gpg | \
+gpg --dearmor | \
+sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt update
+sudo apt-get install terraform
+```
 
-Your VPC structure will dictate which subnet IDs need to be
-chosen for each category here. You must provide at least two
-subnet IDs for the variables that ask for the list. For example,
-AWS Application Load Balancers requires subnets from at least
-two availability zones.
+### Git install
+**OSX:**
+```shell
+brew install git
+```
+**RHEL Linux:**
+```bash
+yum install git
+```
+**Ubuntu/Debian Linux:**
+```shell
+ apt-get install git
+```
 
-A sample configuration can be found in [main.tf](./main.tf).
+### AWS credentials
+You will need a set of AWS Credentials, Terraform uses this to create and install reasources in your AWS environment.
 
+It is recommended for production setups to skip this step and configure the `provider "aws"` block without hard coded credentials,
+but for this example, generate new access keys and save the access key id and secret key for later.  You will be putting them into 
+the `aws_access_key` and `aws_secret_key` variables in [main.tf](./main.tf).  More info can be found in the [official docs for the aws Terraform provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs).
+
+```
+AWS Web UI -> IAM - Users -> Your user -> security credentials tab -> create access key button
+```
+
+### Generate SSH keys
+If you do not have an SSH keypair already (~/.ssh/id_rsa.pub), generate one
+```shell
+ssh-keygen -t rsa -b 4096
+```
+This will be used in a future step for accessing the Bastion host.
+
+## Short Terraform primer
+Terraform will by default install all of the *.tf files in the current directory using the AWS credentials that you provide.  
+
+A few useful commands that will be used in this example:
+* `terraform init` - this downloads and any necessary terraform modules to your local (aws provider etc)
+* `terraform plan` - think of this as a dry run mode.  This reads all of the *.tf files and compares them to AWS to see what needs to be added, removed or updated and prints out a list of proposed changes.
+* `terraform apply` - Prints the same things as terraform plan, but prompts for yes/no to actually execute the changes.
+
+## Bigeye stack install steps
+
+### Ask for access to Bigeye Container Images
+
+The Bigeye stack will launch a number of containers into ECS.  Contact Bigeye support with your 
+AWS Account ID to request your account be given access to these container images.
+
+### Set up the directory that will hold your terraform.
+
+```shell
+mkdir bigeye-stack
+cd bigeye-stack
+```
+
+### Download the Bigeye Terraform examples
+Git Clone the Bigeye Terraform modules repo and copy the self-managed-vpc-no-internet-access example.  The rest of the
+files can be discarded.
+```shell
+git clone https://github.com/bigeyedata/terraform-modules.git
+cp -r terraform-modules/examples/self-managed-vpc-no-internet-access/* .
+rm -rf terraform-modules
+```
+
+### Configure your stack
+Examine and configure every variable in the locals{} block in [main.tf](./main.tf).  Pay particular attention
+to the following settings:
+* aws_region
+* aws_access_key
+* aws_secret_key
+* environment
+* instance
+* parent_domain
+* subdomain_prefix
+* cidr_first_two_octets
+* from_email
+
+The locals block is the only section that needs to be edited for this example.
+
+### Create route53 subdmain
+
+Create the route53 subdomain.  The "-target=aws_route53_zone.this" tells terraform to install a specific resource instead of
+all of the resources found in the *.tf files in the directory.  `aws_route53_zone.this` is defined in [vpc_example.tf](./vpc_example.tf)
+if you wish to inspect how it is defined.
+
+```shell
+terraform init
+terraform apply -target=aws_route53_zone.this
+````
+
+### Create Email account in AWS Workmail
+
+Now that the route53 subdomain has been created, create an AWS Workmail account.  An email client is necessary in order to accept a 
+verification email for AWS SES and Workmail is a native AWS offering so is used here for demonstration purposes.  
+
+There is no Terraform provider for Workmail, so this will be done manually using the AWS Web UI.
+
+[AWS Web UI](https://console.aws.amazon.com) -> Workmail -> Create Organization button
+
+1. `Existing Route 53 domain`: check radio button
+2. `Route 53 hosted zone`: Select the same domain specified in [main.tf](./main.tf) as the subdomain variable
+3. `Alias`: Pick something unique.  bigeye-example-com for example
+
+Now that the Workmail org has been created, we're going to create an email that matches the `${from_email} configured in [main.tf](./main.tf).
+
+Click on the Workmail organization you just created -> Users (left nav) -> Add user button.
+Put whatever you like into the configuration boxes, the only important one is the Email address.
+That must match the `${from_email}` in [main.tf](./main.tf).
+
+Take note of the `username` and `password` fields you have filled in.  Those will be used to log into Workmail to read a verification email from SES later.
+
+### Create the rest of the stack
+```shell
+terraform plan
+terraform apply
+```
+When this completes, the SES identity for `${from_email}` will have been created and SES will have
+sent a verification email to the account.  Log into Workmail https://<workmail_organization>.awsapps.com/mail and
+use the `username` and `password` from above to log in.  Open up the email from "Awamzon Web Services"
+and click on the verify email link so the email address will be verified and SES will allow email to be sent from this address.
+
+### Accessing the Bigeye UI
+Since this demonstration example Terraform plan does not include a VPN and the stack is set up without
+an internet gateway, a bastion will be used for an SSH tunnel to route UI/API requests to Bigeye.  This is 
+here for demonstration purposes, but a VPN is recommended instead for production installs.
+
+Note the output of the Terraform apply when the stack was created.  The last few lines of output will be a few useful values:
+* bastion
+* bastion_ssh_user
+* bigeye_address
+
+Use an SSH tunnel to route requests to the Bigeye application
+
+```shell
+ssh -L 8443:${bigeye_address}:443 -Nf  ubuntu@${bastion}
+```
+
+Update your local /etc/hosts file so that the Bigeye url `${bigeye_address}` will go over the localhost SSH tunnel port.
+
+```shell
+sudo -- sh -c "echo 127.0.0.1 ${vanity_url}.${subdomain}  >> /etc/hosts"
+```
+Point your browser to ${bigeye_address}:8443/first-time to create an account.
+
+Note that the SSH tunnel method is not perfect.  Occasionally there will be a redirect that does
+not come back with the port number in the URL (ie notification emails).  When that happens just add the :8443 port into the URL at the end of `${bigeye_address}`.

--- a/examples/self-managed-vpc-no-internet-access/ec2_bastion_example.tf
+++ b/examples/self-managed-vpc-no-internet-access/ec2_bastion_example.tf
@@ -1,0 +1,63 @@
+# The EC2 bastion can be used as an SSH tunnel for no internet access installs.  This is here for demonstration
+# purposes, a VPN is recommended instead for production.
+
+# Run ssh-keygen -t rsa -b 4096 to create a key pair first if you have not already
+resource "aws_key_pair" "bastion" {
+  count      = local.bastion_enabled ? 1 : 0
+  key_name   = "${local.name}-bastion-ssh"
+  public_key = file(local.bastion_ssh_public_key_file)
+}
+
+resource "aws_security_group" "bastion" {
+  count = local.bastion_enabled ? 1 : 0
+
+  name        = "${local.name}-bastion"
+  description = "Allows traffic to Bastion"
+  vpc_id      = module.vpc.vpc_id
+  tags = {
+    Name = "${local.name}-bastion"
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "TCP"
+    description = "Allow all traffic"
+    cidr_blocks = [local.bastion_ingress_cidr]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+    description      = "Allow all egress"
+  }
+}
+
+resource "aws_instance" "bastion" {
+  count = local.bastion_enabled ? 1 : 0
+  # Ubuntu 22.04 LTS https://cloud-images.ubuntu.com/locator/ec2/
+  ami                         = "ami-08116b9957a259459"
+  instance_type               = "t3.small"
+  key_name                    = aws_key_pair.bastion[0].key_name
+  subnet_id                   = module.vpc.public_subnets[0]
+  associate_public_ip_address = true
+  vpc_security_group_ids      = [aws_security_group.bastion[0].id]
+
+  root_block_device {
+    delete_on_termination = true
+    encrypted             = true
+    volume_type           = "gp3"
+    volume_size           = 10
+    tags = {
+      Name = "Bigeye bastion"
+    }
+  }
+
+  tags = {
+    Name  = "Bigeye bastion"
+    stack = local.name
+  }
+}

--- a/examples/self-managed-vpc-no-internet-access/outputs.tf
+++ b/examples/self-managed-vpc-no-internet-access/outputs.tf
@@ -1,0 +1,15 @@
+output "bigeye_address" {
+  value = "https://${local.vanity_alias}.${local.subdomain}"
+}
+
+output "bigeye_first_time_account_creation_address" {
+  value = "https://${local.vanity_alias}.${local.subdomain}/first-time"
+}
+
+output "bastion" {
+  value = one(aws_instance.bastion[*].public_dns)
+}
+
+output "bastion_ssh_user" {
+  value = format("ssh ubuntu@%s", one(aws_instance.bastion[*].public_dns))
+}

--- a/examples/self-managed-vpc-no-internet-access/secrets_example.tf
+++ b/examples/self-managed-vpc-no-internet-access/secrets_example.tf
@@ -1,0 +1,16 @@
+resource "aws_secretsmanager_secret" "smtp_password" {
+  count                   = local.create_ses_from_email ? 1 : 0
+  name                    = local.byomailserver_smtp_password_aws_secrets_manager_secret_id
+  recovery_window_in_days = 0
+  # The Bigeye module creates an iam role policy allowing access to all secrets with a stack = <stack name> tag set.
+  tags = {
+    stack = local.name
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "smtp_password" {
+  count          = local.create_ses_from_email ? 1 : 0
+  secret_id      = aws_secretsmanager_secret.smtp_password[0].id
+  secret_string  = aws_iam_access_key.from_email[0].ses_smtp_password_v4
+  version_stages = ["AWSCURRENT"]
+}

--- a/examples/self-managed-vpc-no-internet-access/simple_email_server_example.tf
+++ b/examples/self-managed-vpc-no-internet-access/simple_email_server_example.tf
@@ -1,0 +1,92 @@
+#######################################################################
+# SES is optional and here to facilitate testing a BYO email server install.
+# Most BYO VPC examples will not use this file and will supply an existing
+# SMTP server.
+#######################################################################
+
+data "aws_iam_policy_document" "this" {
+  statement {
+    actions   = ["ses:SendEmail", "ses:SendRawEmail", "ses:SendTemplatedEmail", "ses:SendBulkTemplatedEmail"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_ses_email_identity" "from_email" {
+  count = local.create_ses_from_email ? 1 : 0
+  email = local.from_email
+}
+
+# Provides an IAM access key. This is a set of credentials that allow API requests to be made as an IAM user.
+resource "aws_iam_user" "from_email" {
+  count = local.create_ses_from_email ? 1 : 0
+  name  = local.ses_iam_user_name
+}
+
+resource "aws_iam_access_key" "from_email" {
+  count = local.create_ses_from_email ? 1 : 0
+  user  = aws_iam_user.from_email[0].name
+}
+
+resource "aws_iam_policy" "from_email" {
+  count  = local.create_ses_from_email ? 1 : 0
+  name   = local.ses_iam_user_name
+  policy = data.aws_iam_policy_document.this.json
+}
+
+resource "aws_iam_user_policy_attachment" "from_email" {
+  count      = local.create_ses_from_email ? 1 : 0
+  user       = aws_iam_user.from_email[0].name
+  policy_arn = aws_iam_policy.from_email[0].arn
+}
+
+resource "aws_route53_record" "subdomain_spf" {
+  zone_id = aws_route53_zone.subdomain.zone_id
+  name    = "${local.subdomain}."
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=spf1 include:amazonses.com ~all"]
+}
+
+resource "aws_route53_record" "subdomain_dmarc" {
+  zone_id = aws_route53_zone.subdomain.zone_id
+  name    = "_dmarc.${local.subdomain}."
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=DMARC1;p=quarantine;pct=100;fo=1"]
+}
+
+# VPC Endpoint for SES is recommended when using AWS SES for mail delivery to avoid email being sent over public net.
+resource "aws_security_group" "smtp_vpce" {
+  name   = "${local.name}-smtp-vpce"
+  vpc_id = module.vpc.vpc_id
+
+  ingress {
+    from_port   = local.byomailserver_smtp_port
+    to_port     = local.byomailserver_smtp_port
+    protocol    = "tcp"
+    cidr_blocks = [module.vpc.vpc_cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    "Name" = "${local.name}-smtp-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "smtp_vpce" {
+  security_group_ids  = [aws_security_group.smtp_vpce.id]
+  service_name        = "com.amazonaws.${local.aws_region}.email-smtp"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = module.vpc.private_subnets
+  private_dns_enabled = true
+  tags = {
+    "Name" = "${local.name}-smtp-endpoint"
+  }
+  vpc_id = module.vpc.vpc_id
+}

--- a/examples/self-managed-vpc-no-internet-access/subdomain_example.tf
+++ b/examples/self-managed-vpc-no-internet-access/subdomain_example.tf
@@ -1,0 +1,21 @@
+# This example registers a subdomain in your already registered domain.
+# Registering a root level domain name involves a commitment from a Domain Name Registrar
+# for a minimum of 12 months so is beyond the scope of this example.
+data "aws_route53_zone" "parent_domain" {
+  name         = local.parent_domain
+  private_zone = false
+}
+
+resource "aws_route53_zone" "subdomain" {
+  name          = local.subdomain
+  force_destroy = true
+}
+
+# Record in the parent domain for the nameservers in the subdomain must be created
+resource "aws_route53_record" "subdomain_ns_record" {
+  type    = "NS"
+  zone_id = data.aws_route53_zone.parent_domain.zone_id
+  name    = local.subdomain_prefix
+  ttl     = 300
+  records = aws_route53_zone.subdomain.name_servers
+}


### PR DESCRIPTION
There are tons of new features now, update this set of instructions with a working end to end install.  Normal installs will only require what's in main.tf, but for the purpose of creating a functional end to end install, all of the addtional *_example.tf files have been added to create addtional resources necessary such as SES, Workmail, a bastion for SSH tunnel, etc.