### PR TITLE
docs: restrict IPs to local subnet in no-internet example

### DIFF
--- a/examples/self-managed-vpc-no-internet-access/ec2_bastion_example.tf
+++ b/examples/self-managed-vpc-no-internet-access/ec2_bastion_example.tf
@@ -23,16 +23,15 @@ resource "aws_security_group" "bastion" {
     to_port     = 22
     protocol    = "TCP"
     description = "Allow all traffic"
-    cidr_blocks = [local.bastion_ingress_cidr]
+    cidr_blocks = [local.external_access_cidr]
   }
 
   egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allow all egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [local.cidr_block, local.external_access_cidr]
+    description = "Allow all egress"
   }
 }
 

--- a/examples/self-managed-vpc-no-internet-access/main.tf
+++ b/examples/self-managed-vpc-no-internet-access/main.tf
@@ -5,10 +5,11 @@ locals {
   aws_access_key = "<your aws_access_key>"
   aws_secret_key = "<your aws_secret_key>"
 
-  # https://whatsmyip.com can be used to get your IP if you don't have it.  This ingres cidr goes into the
-  # security group allowing access to the bastion.  This should be the IP address from where you will be
-  # using a browser or making API calls to Bigeye from.
-  bastion_ingress_cidr = "<your ip address>/32"
+  # https://whatsmyip.com can be used to get your IP if you don't have it.  This should be the IP address from where
+  # you will be using a browser or making API calls to Bigeye from.
+  # This is only used for access to the bastion.  Ingress is only allowed from this cidr for the bastion and only
+  # outbound to this address and the vpc cidr.
+  external_access_cidr = "<your ip address>/32"
 
   environment = "test"
   instance    = "bigeye"

--- a/examples/self-managed-vpc-no-internet-access/simple_email_server_example.tf
+++ b/examples/self-managed-vpc-no-internet-access/simple_email_server_example.tf
@@ -71,7 +71,7 @@ resource "aws_security_group" "smtp_vpce" {
     from_port   = 0
     protocol    = "-1"
     to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [local.cidr_block]
   }
 
   tags = {

--- a/examples/self-managed-vpc-no-internet-access/vpc_example.tf
+++ b/examples/self-managed-vpc-no-internet-access/vpc_example.tf
@@ -112,12 +112,11 @@ resource "aws_security_group" "vpc_endpoint" {
   }
 
   egress {
-    from_port        = 0
-    to_port          = 65535
-    protocol         = "TCP"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allow all egress"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allow all egress"
   }
 }
 
@@ -195,12 +194,11 @@ resource "aws_security_group" "rabbitmq" {
   }
 
   egress {
-    from_port        = 0
-    to_port          = 65535
-    protocol         = "TCP"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allows egress"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allows egress"
   }
 }
 
@@ -211,21 +209,19 @@ resource "aws_security_group" "temporal" {
   description = "Allows port 7233"
 
   ingress {
-    from_port        = 7233
-    to_port          = 7233
-    protocol         = "TCP"
-    cidr_blocks      = [local.cidr_block]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allow temporal traffic"
+    from_port   = 7233
+    to_port     = 7233
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allow temporal traffic"
   }
 
   egress {
-    from_port        = 0
-    to_port          = 65535
-    protocol         = "TCP"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allows egress"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allows egress"
   }
 }
 
@@ -244,12 +240,11 @@ resource "aws_security_group" "rds" {
   }
 
   egress {
-    from_port        = 0
-    to_port          = 65535
-    protocol         = "TCP"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allows egress"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allows egress"
   }
 }
 
@@ -268,12 +263,11 @@ resource "aws_security_group" "redis" {
   }
 
   egress {
-    from_port        = 0
-    to_port          = 65535
-    protocol         = "TCP"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allows egress"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allows egress"
   }
 }
 
@@ -284,30 +278,27 @@ resource "aws_security_group" "services" {
   description = "Allows port 80/443"
 
   ingress {
-    from_port        = 80
-    to_port          = 80
-    protocol         = "TCP"
-    cidr_blocks      = [local.cidr_block]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allow HTTP traffic"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allow HTTP traffic"
   }
 
   ingress {
-    from_port        = 443
-    to_port          = 443
-    protocol         = "TCP"
-    cidr_blocks      = [local.cidr_block]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allow HTTPS traffic"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allow HTTPS traffic"
   }
 
   egress {
-    from_port        = 0
-    to_port          = 65535
-    protocol         = "TCP"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allows egress"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allows egress"
   }
 }
 
@@ -318,29 +309,26 @@ resource "aws_security_group" "http" {
   description = "Allows port 80/443"
 
   ingress {
-    from_port        = 80
-    to_port          = 80
-    protocol         = "TCP"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allow HTTP traffic"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allow HTTP traffic"
   }
 
   ingress {
-    from_port        = 443
-    to_port          = 443
-    protocol         = "TCP"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allow HTTPS traffic"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allow HTTPS traffic"
   }
 
   egress {
-    from_port        = 0
-    to_port          = 65535
-    protocol         = "TCP"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-    description      = "Allows egress"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "TCP"
+    cidr_blocks = [local.cidr_block]
+    description = "Allows egress"
   }
 }


### PR DESCRIPTION
This currently relies on the networking routes/subnets to prevent external access.  We should also be restricting the security groups to only allow ingress/egress from the VPC cidr in this example to add a 2nd layer of protection to the security moat.