### PR TITLE
docs: fix bug with no-internet vpc example and ECR privatelink

### DIFF
--- a/examples/self-managed-vpc-no-internet-access/README.md
+++ b/examples/self-managed-vpc-no-internet-access/README.md
@@ -186,10 +186,12 @@ Now that the Workmail org has been created, we're going to create an email that 
 Wait for the Workmail org that you created to finish creating and become `Active` (the browser refreshes status automatically). 
 Click on 
 
-Workmail organization (e.g. bigeye-example-com) -> Users (left nav) -> Add user button.
+`Workmail organization (e.g. bigeye-example-com) -> Users (left nav) -> Add user button.`
 
 Put whatever you like into the configuration boxes, the only important one is the Email address.
-That must match the `${from_email}` in [main.tf](./main.tf), be sure to set the @domain dropdown box to your subdomain. 
+That must match the `${from_email}` in [main.tf](./main.tf), be sure to set the @domain dropdown box to your subdomain.
+If the drop down is empty or your subdomain isn't in the list, just wait a minute or two and refresh the page.  DNS verification
+is happening in the background and this can take a few minutes.
 
 Take note of the `username` and `password` fields you have filled in.  Those will be used to log into Workmail to read a verification email from SES later.
 

--- a/examples/self-managed-vpc-no-internet-access/simple_email_server_example.tf
+++ b/examples/self-managed-vpc-no-internet-access/simple_email_server_example.tf
@@ -55,32 +55,8 @@ resource "aws_route53_record" "subdomain_dmarc" {
   records = ["v=DMARC1;p=quarantine;pct=100;fo=1"]
 }
 
-# VPC Endpoint for SES is recommended when using AWS SES for mail delivery to avoid email being sent over public net.
-resource "aws_security_group" "smtp_vpce" {
-  name   = "${local.name}-smtp-vpce"
-  vpc_id = module.vpc.vpc_id
-
-  ingress {
-    from_port   = local.byomailserver_smtp_port
-    to_port     = local.byomailserver_smtp_port
-    protocol    = "tcp"
-    cidr_blocks = [module.vpc.vpc_cidr_block]
-  }
-
-  egress {
-    from_port   = 0
-    protocol    = "-1"
-    to_port     = 0
-    cidr_blocks = [local.cidr_block]
-  }
-
-  tags = {
-    "Name" = "${local.name}-smtp-endpoint"
-  }
-}
-
 resource "aws_vpc_endpoint" "smtp_vpce" {
-  security_group_ids  = [aws_security_group.smtp_vpce.id]
+  security_group_ids  = [aws_security_group.vpc_endpoint.id]
   service_name        = "com.amazonaws.${local.aws_region}.email-smtp"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = module.vpc.private_subnets


### PR DESCRIPTION
A couple things in this PR that are subtle.

1. There is what I would call a bug with ECR privatelink that both an S3 gateway and S3 interface endpoint must be created or ECR image pulls will fail due to some portion of the request chain going out over public net (even though we don't even have a route to public net).

This is solved in our example TF by adding a S3 *Interface* VPCE and it specifically must have private_dns_only_for_inbound_resolver_endpoint set to false or the requests still end up resolving with a public IP and thus failing.

2. The terraform-aws-modules/vpc/aws//modules/vpc-endpoints version that we were using had a bug where private_dns_only_for_inbound_resolver_endpoint was not getting applied to the VPCE.  Updating to > 5.5.0 fixes that problem as well.

With these changes, the example is now able to work with security group rules completely restricted to just the VPC CIDR for all security group ingress and egress rules.