### PR TITLE
fix: scheduler datawatch address to datawork

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1869,7 +1869,7 @@ module "scheduler" {
       INSTANCE              = var.instance
       PORT                  = var.scheduler_port
       DEPLOY_TYPE           = "AWS"
-      DATAWATCH_ADDRESS     = "https://${local.datawatch_dns_name}"
+      DATAWATCH_ADDRESS     = "https://${local.datawork_dns_name}"
       MAX_RAM_PERCENTAGE    = "85"
       SCHEDULER_ADDRESS     = "http://localhost:${var.scheduler_port}"
       SCHEDULER_THREADS     = var.scheduler_threads


### PR DESCRIPTION
Scheduler is producing background work that should be sent to a background worker - datawork.