### PR TITLE
feat: allow setting replica DB engine version

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2146,6 +2146,7 @@ module "datawatch_rds" {
 
   # Replica
   create_replica                  = var.datawatch_rds_replica_enabled
+  replica_engine_version          = var.datawatch_rds_replica_engine_version
   replica_instance_class          = var.datawatch_rds_replica_instance_type
   replica_backup_retention_period = var.datawatch_rds_replica_backup_retention_period
 

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1167,6 +1167,12 @@ variable "datawatch_rds_replica_enabled" {
   default     = false
 }
 
+variable "datawatch_rds_replica_engine_version" {
+  description = "Defaults to engine_version.  This is primarily used for engine upgrades as the replica has to be upgraded first."
+  type        = string
+  default     = ""
+}
+
 variable "datawatch_rds_replica_instance_type" {
   description = "The instance type to use for datawatch read replica"
   type        = string

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -154,7 +154,7 @@ module "replica" {
   apply_immediately                   = var.apply_immediately
   identifier                          = "${var.name}-ro"
   engine                              = "mysql"
-  engine_version                      = var.engine_version
+  engine_version                      = var.replica_engine_version != "" ? var.replica_engine_version : var.engine_version
   auto_minor_version_upgrade          = false
   instance_class                      = var.replica_instance_class
   deletion_protection                 = var.deletion_protection

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -181,6 +181,13 @@ variable "create_replica" {
   default     = false
 }
 
+variable "replica_engine_version" {
+  description = "Defaults to engine_version.  This is primarily used for engine upgrades as the replica has to be upgraded first."
+  type        = string
+  default     = ""
+}
+
+
 variable "replica_instance_class" {
   description = "Instance class of the replica"
   type        = string


### PR DESCRIPTION
This is useful when upgrading mysql DB engines as the replica has to be updated before the primary.