### PR TITLE
feat: enable performance insights on datawatch mysql replica

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -81,12 +81,14 @@ locals {
   temporal_mysql_dns_name  = local.use_rds_vanity_names ? local.temporal_mysql_vanity_dns_name : module.temporal_rds.primary_dns_name
 
   # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.Engines.html
-  performance_insights_unavailable_instance_types = ["db.t2.micro", "db.t2.small", "db.t3.micro", "db.t3.small", "db.t4g.micro", "db.t4g.small"]
-  datawatch_rds_performance_insights_available    = !contains(local.performance_insights_unavailable_instance_types, var.datawatch_rds_instance_type) ? true : false
-  datawatch_rds_performance_insights_enabled      = coalesce(var.datawatch_rds_enable_performance_insights, local.datawatch_rds_performance_insights_available)
-  temporal_rds_performance_insights_available     = !contains(local.performance_insights_unavailable_instance_types, var.temporal_rds_instance_type) ? true : false
-  temporal_rds_performance_insights_enabled       = coalesce(var.temporal_rds_enable_performance_insights, local.temporal_rds_performance_insights_available)
-  temporal_rds_create_parameter_group             = length(var.temporal_rds_parameters) > 0
+  performance_insights_unavailable_instance_types      = ["db.t2.micro", "db.t2.small", "db.t3.micro", "db.t3.small", "db.t4g.micro", "db.t4g.small"]
+  datawatch_rds_performance_insights_available         = !contains(local.performance_insights_unavailable_instance_types, var.datawatch_rds_instance_type) ? true : false
+  datawatch_rds_performance_insights_enabled           = coalesce(var.datawatch_rds_enable_performance_insights, local.datawatch_rds_performance_insights_available)
+  datawatch_rds_replica_performance_insights_available = !contains(local.performance_insights_unavailable_instance_types, var.datawatch_rds_replica_instance_type) ? true : false
+  datawatch_rds_replica_performance_insights_enabled   = coalesce(var.datawatch_rds_enable_performance_insights, local.datawatch_rds_replica_performance_insights_available)
+  temporal_rds_performance_insights_available          = !contains(local.performance_insights_unavailable_instance_types, var.temporal_rds_instance_type) ? true : false
+  temporal_rds_performance_insights_enabled            = coalesce(var.temporal_rds_enable_performance_insights, local.temporal_rds_performance_insights_available)
+  temporal_rds_create_parameter_group                  = length(var.temporal_rds_parameters) > 0
 
   create_acm_cert           = var.acm_certificate_arn == "" ? true : false
   domain_validation_options = local.create_acm_cert ? aws_acm_certificate.wildcard[0].domain_validation_options : []

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2176,10 +2176,12 @@ module "datawatch_rds" {
   parameters             = var.datawatch_rds_parameters
 
   # Replica
-  create_replica                  = var.datawatch_rds_replica_enabled
-  replica_engine_version          = var.datawatch_rds_replica_engine_version
-  replica_instance_class          = var.datawatch_rds_replica_instance_type
-  replica_backup_retention_period = var.datawatch_rds_replica_backup_retention_period
+  create_replica                                = var.datawatch_rds_replica_enabled
+  replica_engine_version                        = var.datawatch_rds_replica_engine_version
+  replica_instance_class                        = var.datawatch_rds_replica_instance_type
+  replica_backup_retention_period               = var.datawatch_rds_replica_backup_retention_period
+  replica_enable_performance_insights           = local.datawatch_rds_replica_performance_insights_enabled
+  replica_performance_insights_retention_period = var.replica_rds_performance_insights_retention_period
 
   replica_create_parameter_group = true
   replica_parameter_group_name   = "${local.name}-datawatch-replica"

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -661,6 +661,11 @@ variable "rds_apply_immediately" {
   default     = false
 }
 
+variable "replica_rds_performance_insights_retention_period" {
+  description = "Days to keep performance insights for the replica"
+  type        = number
+  default     = 7
+}
 
 #======================================================
 # Application Variables - HAProxy

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -196,7 +196,7 @@ module "replica" {
   storage_encrypted     = true
 
   performance_insights_enabled          = var.replica_enable_performance_insights
-  performance_insights_retention_period = var.performance_insights_retention_period
+  performance_insights_retention_period = var.replica_performance_insights_retention_period
   monitoring_interval                   = var.enhanced_monitoring_interval
   monitoring_role_arn                   = var.enhanced_monitoring_role_arn
   backup_window                         = var.backup_window

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -187,7 +187,6 @@ variable "replica_engine_version" {
   default     = ""
 }
 
-
 variable "replica_instance_class" {
   description = "Instance class of the replica"
   type        = string
@@ -198,6 +197,12 @@ variable "replica_enable_performance_insights" {
   description = "Whether to enable performance insights on the replica"
   type        = bool
   default     = false
+}
+
+variable "replica_performance_insights_retention_period" {
+  description = "days to keep performance insights on the replica"
+  type        = number
+  default     = 7
 }
 
 variable "replica_create_parameter_group" {


### PR DESCRIPTION
It can be useful to have performance insights on the replica as well.  There is no cost for 7days of data so it might as well be on.