### PR TITLE
fix: update logic enabling performance insights on RDS

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -83,11 +83,11 @@ locals {
   # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.Engines.html
   performance_insights_unavailable_instance_types      = ["db.t2.micro", "db.t2.small", "db.t3.micro", "db.t3.small", "db.t4g.micro", "db.t4g.small"]
   datawatch_rds_performance_insights_available         = !contains(local.performance_insights_unavailable_instance_types, var.datawatch_rds_instance_type) ? true : false
-  datawatch_rds_performance_insights_enabled           = coalesce(var.datawatch_rds_enable_performance_insights, local.datawatch_rds_performance_insights_available)
+  datawatch_rds_performance_insights_enabled           = alltrue([var.datawatch_rds_enable_performance_insights, local.datawatch_rds_performance_insights_available])
   datawatch_rds_replica_performance_insights_available = !contains(local.performance_insights_unavailable_instance_types, var.datawatch_rds_replica_instance_type) ? true : false
-  datawatch_rds_replica_performance_insights_enabled   = coalesce(var.datawatch_rds_enable_performance_insights, local.datawatch_rds_replica_performance_insights_available)
+  datawatch_rds_replica_performance_insights_enabled   = alltrue([var.datawatch_rds_enable_performance_insights, local.datawatch_rds_replica_performance_insights_available])
   temporal_rds_performance_insights_available          = !contains(local.performance_insights_unavailable_instance_types, var.temporal_rds_instance_type) ? true : false
-  temporal_rds_performance_insights_enabled            = coalesce(var.temporal_rds_enable_performance_insights, local.temporal_rds_performance_insights_available)
+  temporal_rds_performance_insights_enabled            = alltrue([var.temporal_rds_enable_performance_insights, local.temporal_rds_performance_insights_available])
   temporal_rds_create_parameter_group                  = length(var.temporal_rds_parameters) > 0
 
   create_acm_cert           = var.acm_certificate_arn == "" ? true : false


### PR DESCRIPTION
This should be an alltrue (ie flag must be on + DB in allowed hardware list) in order to be enabled.  Since coalesce accepts the first true, it is skipping the instance type validation.