### PR TITLE
fix: set default for performance insights back to true

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -890,9 +890,9 @@ variable "temporal_rds_engine_version" {
 }
 
 variable "temporal_rds_enable_performance_insights" {
-  description = "Whether to enable performance insights. If not specified, will default to on if the database type supports it"
+  description = "Whether to enable performance insights. Default to true if the database type supports it"
   type        = bool
-  default     = null
+  default     = true
 }
 
 variable "temporal_rds_backup_retention_period" {
@@ -1114,9 +1114,9 @@ variable "datawatch_rds_engine_version" {
 }
 
 variable "datawatch_rds_enable_performance_insights" {
-  description = "Whether to enable performance insights. If not specified, will default to on if the database type supports it"
+  description = "Whether to enable performance insights. Default to true if the database type supports it"
   type        = bool
-  default     = null
+  default     = true
 }
 
 variable "datawatch_rds_enhanced_monitoring_interval" {

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -106,7 +106,7 @@ variable "enable_multi_az" {
 variable "enable_performance_insights" {
   description = "Whether to enable performance insights"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "performance_insights_retention_period" {


### PR DESCRIPTION
RDS Performance insights are inexpensive enough that it is recommended this is on for all databaess (where the hardware supports it).  The change in 3.11.1 fixed the logic for enabling only if the hardware is not in the blacklist, but ended up disabling performance monitoring by default. This fix turns it back on by default.