### PR TITLE
Do not control desired_count when autoscaling is enabled

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1207,6 +1207,7 @@ module "monocle" {
   lb_access_logs_bucket_prefix = format("%s-%s", local.elb_access_logs_prefix, "monocle")
 
   # Task settings
+  control_desired_count     = var.monocle_autoscaling_enabled ? false : true
   desired_count             = var.monocle_desired_count
   cpu                       = var.monocle_cpu
   memory                    = var.monocle_memory
@@ -1335,6 +1336,7 @@ module "toretto" {
   lb_access_logs_bucket_prefix = format("%s-%s", local.elb_access_logs_prefix, "toretto")
 
   # Task settings
+  control_desired_count     = var.toretto_autoscaling_enabled ? false : true
   desired_count             = var.toretto_desired_count
   cpu                       = var.toretto_cpu
   memory                    = var.toretto_memory

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -512,7 +512,7 @@ variable "monocle_lb_extra_security_group_ids" {
 }
 
 variable "monocle_autoscaling_enabled" {
-  description = "Whether monocle autoscaling is enabled"
+  description = "Whether monocle autoscaling is enabled. Note - if you change this variable, it changes the terraform resource that is created. You must run 'terraform state mv' in order to gracefully make this change"
   type        = bool
   default     = false
 }
@@ -599,7 +599,7 @@ variable "toretto_lb_extra_security_group_ids" {
 }
 
 variable "toretto_autoscaling_enabled" {
-  description = "Whether to scale toretto based on queue depth"
+  description = "Whether toretto autoscaling is enabled. Note - if you change this variable, it changes the terraform resource that is created. You must run 'terraform state mv' in order to gracefully make this change"
   type        = bool
   default     = false
 }

--- a/modules/simpleservice/outputs.tf
+++ b/modules/simpleservice/outputs.tf
@@ -1,6 +1,6 @@
 output "ecs_service_arn" {
   description = "The ARN of the ecs service"
-  value       = aws_ecs_service.this.id
+  value       = var.control_desired_count ? aws_ecs_service.controlled_count[0].id : aws_ecs_service.uncontrolled_count[0].id
 }
 
 output "dns_name" {

--- a/modules/simpleservice/variables.tf
+++ b/modules/simpleservice/variables.tf
@@ -81,6 +81,12 @@ variable "desired_count" {
   type        = number
 }
 
+variable "control_desired_count" {
+  description = "whether to control the desired count. If autoscaling, this should be false. Otherwise it should be true. If you change this value, you will need to run 'terraform state mv' to move resource from the controlled_count resource to uncontrolled_count"
+  type        = bool
+  default     = true
+}
+
 variable "cpu" {
   description = "The number of CPU units required by the Fargate task, e.g. 2. See - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html#fargate-tasks-size"
   type        = number


### PR DESCRIPTION
Previously, every time terraform applied changes, it would reset the desired_count of autoscaled services to their initial value, regardless of what the application autoscaling setting was at.

BREAKING CHANGE: The resource name for the aws_ecs_service's in the simpleservice module have been changed to reflect whether the desired_count is controlled.

Recommendation: Use 'terraform state mv' command to move existing ECS resources into their respective new names.

Downtime: Yes, if you do not follow these upgrade steps. No, if you use the 'terraform state mv' commands outlined in these upgrade steps.

Steps: You should run a series of terraform state mv commands. These commands will tell Terraform that the AWS ECS Services already exist, and that they just use a different name now.

Depending on how you have named your bigeye module in your terraform file, the following commands may need to be modified to align with your usage. Always inspect the output of 'terraform apply'.

Run the following steps:

```sh
terraform state mv \
    'module.bigeye.module.web.aws_ecs_service.this' \
    'module.bigeye.module.web.aws_ecs_service.controlled_count[0]'

terraform state mv \
    'module.bigeye.module.temporalui.aws_ecs_service.this' \
    'module.bigeye.module.temporalui.aws_ecs_service.controlled_count[0]'

terraform state mv \
    'module.bigeye.module.datawatch.aws_ecs_service.this' \
    'module.bigeye.module.datawatch.aws_ecs_service.controlled_count[0]'

terraform state mv \
    'module.bigeye.module.datawork.aws_ecs_service.this' \
    'module.bigeye.module.datawork.aws_ecs_service.controlled_count[0]'

terraform state mv \
    'module.bigeye.module.metricwork.aws_ecs_service.this' \
    'module.bigeye.module.metricwork.aws_ecs_service.controlled_count[0]'

terraform state mv \
    'module.bigeye.module.scheduler.aws_ecs_service.this' \
    'module.bigeye.module.scheduler.aws_ecs_service.controlled_count[0]'

terraform state mv \
    'module.bigeye.module.haproxy.aws_ecs_service.this' \
    'module.bigeye.module.haproxy.aws_ecs_service.controlled_count[0]'
```

Then, if you have autoscaling enabled for monocle and toretto, you will run:

```sh
terraform state mv \
    'module.bigeye.module.toretto.aws_ecs_service.this' \
    'module.bigeye.module.toretto.aws_ecs_service.uncontrolled_count[0]'

terraform state mv \
    'module.bigeye.module.monocle.aws_ecs_service.this' \
    'module.bigeye.module.monocle.aws_ecs_service.uncontrolled_count[0]'
```
Or, if you do not have autoscaling enabled for monocle and toretto, you will run:

```sh
terraform state mv \
    'module.bigeye.module.toretto.aws_ecs_service.this' \
    'module.bigeye.module.toretto.aws_ecs_service.controlled_count[0]'

terraform state mv \
    'module.bigeye.module.monocle.aws_ecs_service.this' \
    'module.bigeye.module.monocle.aws_ecs_service.controlled_count[0]'
```