### PR TITLE
Fix default Opensearch zone awareness count

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1017,7 +1017,7 @@ variable "temporal_opensearch_enable_master_nodes" {
 variable "temporal_opensearch_master_instance_type" {
   description = "The opensearch instance type to use for master nodes"
   type        = string
-  default     = "m6g.large.search"
+  default     = "t3.medium.search"
 }
 
 variable "temporal_opensearch_zone_awareness_zone_count" {

--- a/modules/opensearch/main.tf
+++ b/modules/opensearch/main.tf
@@ -1,7 +1,6 @@
 locals {
-  max_port             = 65535
-  relevant_subnet_ids  = var.instance_count < length(var.subnet_ids) ? slice(var.subnet_ids, 0, var.instance_count) : var.subnet_ids
-  zone_awareness_count = coalesce(var.zone_awareness_zone_count, length(local.relevant_subnet_ids))
+  max_port            = 65535
+  relevant_subnet_ids = var.instance_count < length(var.subnet_ids) ? slice(var.subnet_ids, 0, var.instance_count) : var.subnet_ids
 }
 
 resource "aws_security_group" "this" {
@@ -72,7 +71,7 @@ resource "aws_opensearch_domain" "this" {
   cluster_config {
     zone_awareness_enabled = var.instance_count > 1
     zone_awareness_config {
-      availability_zone_count = local.zone_awareness_count
+      availability_zone_count = 3
     }
     instance_count           = var.instance_count
     instance_type            = var.instance_type

--- a/modules/opensearch/main.tf
+++ b/modules/opensearch/main.tf
@@ -1,6 +1,8 @@
 locals {
   max_port            = 65535
   relevant_subnet_ids = var.instance_count < length(var.subnet_ids) ? slice(var.subnet_ids, 0, var.instance_count) : var.subnet_ids
+  # Burstable class hardware is not supported for auto tune.
+  auto_tune_enabled = !can(regex("^t", var.master_node_instance_type))
 }
 
 resource "aws_security_group" "this" {
@@ -112,6 +114,9 @@ resource "aws_opensearch_domain" "this" {
     iops        = var.ebs_iops
     volume_size = var.ebs_size
     volume_type = "gp3"
+  }
+  auto_tune_options {
+    desired_state = local.auto_tune_enabled ? "ENABLED" : "DISABLED"
   }
 }
 


### PR DESCRIPTION
commit 84710ca1c43a1fa55e724b25d8617f758c0f5bdd (HEAD -> david/sre-3304-opensearch-1-is-not-an-allowed-value-for, origin/david/sre-3304-opensearch-1-is-not-an-allowed-value-for)
Author: David Nguyen <david@bigeye.com>
Date:   Tue May 14 13:04:15 2024 -0700

    fix: set opensearch data and master node types to the same

    Mix and match between intel and Graviton is not allowed.  Keep these
    the same.  Also auto_tune is not allowed for t3 instance types.

    Closes SRE-3305

commit 669b3d56638b255d3e8024654e44582a47f3dbc5
Author: David Nguyen <david@bigeye.com>
Date:   Tue May 14 12:56:55 2024 -0700

    fix: always use 3 opensearch zones if zone aware is enabled

    Valid options are 2 or 3 (1 is not allowed, so is a bug currently).

    We should always use the recommended 3, especially since we are
    setting the master node count as 3.