### PR TITLE
fix: update password strength rules for generated opensearch password

### DIFF
--- a/modules/bigeye/temporal.tf
+++ b/modules/bigeye/temporal.tf
@@ -644,11 +644,17 @@ module "temporalui" {
 # Temporal-Elasticsearch
 #======================================================
 resource "random_password" "temporal_opensearch_password" {
-  count   = local.create_temporal_opensearch_password_secret ? 1 : 0
-  length  = 16
-  special = true
-  upper   = true
-  numeric = true
+  count       = local.create_temporal_opensearch_password_secret ? 1 : 0
+  length      = 16
+  special     = true
+  upper       = true
+  lower       = true
+  numeric     = true
+  min_special = 1
+  min_lower   = 1
+  min_upper   = 1
+  min_numeric = 1
+
 }
 
 resource "aws_secretsmanager_secret" "temporal_opensearch_password" {


### PR DESCRIPTION
    The random password that gets generated was occiasionally missing
    some of the required chars, which fails opensearch password validation.