### PR TITLE
fix: update opernsearch autotune rollback setting

### DIFF
--- a/modules/opensearch/main.tf
+++ b/modules/opensearch/main.tf
@@ -122,7 +122,8 @@ resource "aws_opensearch_domain" "this" {
     volume_type = "gp3"
   }
   auto_tune_options {
-    desired_state = local.auto_tune_enabled ? "ENABLED" : "DISABLED"
+    desired_state       = local.auto_tune_enabled ? "ENABLED" : "DISABLED"
+    rollback_on_disable = "NO_ROLLBACK"
   }
 }
 


### PR DESCRIPTION
This is a required arg to have set, no rollback seems reasonable to avoid a deployment when autotune is disabled, which should be rare.