### PR TITLE
refactor: control opensearch redeundancy with var.redundant_infrastru…

### DIFF
--- a/modules/bigeye/temporal.tf
+++ b/modules/bigeye/temporal.tf
@@ -690,10 +690,9 @@ module "temporal_opensearch" {
   additional_ingress_cidrs   = var.internal_additional_ingress_cidrs
   engine_version             = var.temporal_opensearch_engine_version
   instance_type              = var.temporal_opensearch_instance_type
-  instance_count             = var.temporal_opensearch_instance_count
+  instance_count             = var.redundant_infrastructure ? 3 : 1
   subnet_ids                 = local.rabbitmq_subnet_group_ids
   master_user_password       = local.create_temporal_opensearch_password_secret ? random_password.temporal_opensearch_password[0].result : data.aws_secretsmanager_secret_version.byo_temporal_opensearch_password[0].secret_string
-  master_nodes_enabled       = var.temporal_opensearch_enable_master_nodes
+  master_nodes_enabled       = var.redundant_infrastructure ? true : false
   master_node_instance_type  = var.temporal_opensearch_master_instance_type
-  zone_awareness_zone_count  = var.temporal_opensearch_zone_awareness_zone_count
 }

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1002,12 +1002,6 @@ variable "temporal_opensearch_instance_type" {
   default     = "t3.medium.search"
 }
 
-variable "temporal_opensearch_instance_count" {
-  description = "The number of data nodes"
-  type        = number
-  default     = 1
-}
-
 variable "temporal_opensearch_master_user_password_secret_arn" {
   description = "ARN for secretsmanager secret holding the opensearch master user password. One will be created if not provided."
   type        = string
@@ -1020,22 +1014,10 @@ variable "temporal_opensearch_extra_security_group_ids" {
   default     = []
 }
 
-variable "temporal_opensearch_enable_master_nodes" {
-  description = "Whether to enable master nodes to offload administrative tasks. Recommended for production systems"
-  type        = bool
-  default     = true
-}
-
 variable "temporal_opensearch_master_instance_type" {
-  description = "The opensearch instance type to use for master nodes"
+  description = "The opensearch instance type to use for master nodes.  Only applicable if var.redundant_infrastructure = true"
   type        = string
   default     = "t3.medium.search"
-}
-
-variable "temporal_opensearch_zone_awareness_zone_count" {
-  description = "The number of AZs the domain is aware of. Will default to the number of subnets, or instance count, whichever is lowest"
-  type        = number
-  default     = null
 }
 
 #======================================================

--- a/modules/opensearch/variables.tf
+++ b/modules/opensearch/variables.tf
@@ -63,12 +63,6 @@ variable "master_node_instance_type" {
   type        = string
 }
 
-variable "zone_awareness_zone_count" {
-  description = "Zone awareness count. Specify this if it's different than the number of subnets"
-  type        = number
-  default     = null
-}
-
 variable "subnet_ids" {
   description = "list of subnet ids to launch in to"
   type        = list(string)


### PR DESCRIPTION
…cture

There were several knobs controlling opensearch redunancy.  Hard code these in so it is all driven from the var.redundant_infrastructure varaible to streamline the interface and avoid mistakes.

BREAKING_CHANGE: The following variables have been removed
- temporal_opensearch_instance_count
- temporal_opensearch_enable_master_nodes
- temporal_opensearch_zone_awareness_zone_count

These are now no longer settable, but instead controlled via var.redundant_infrastructure.