### PR TITLE
feat: allow using firelens for ECS logs

### DIFF
--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -35,7 +35,7 @@ variable "cluster_name" {
 }
 
 variable "cloudwatch_log_group_name" {
-  description = "Where to send cloudwatch logs"
+  description = "Cloudwatch log group name to write container logs.  If var.awsfirelens_enabled = true, container logs are shipped via AWS firelens and not cloudwatch.  The AWS firelens side car container though is the exception and will continue to send logs to cloudwatch logs even if var.awsfirelens_enabled = true to facilitate debugging firelens issues."
   type        = string
 }
 
@@ -243,6 +243,45 @@ variable "rabbitmq_password_secret_arn" {
 
 variable "task_iam_role_arn" {
   description = "The ECS Task IAM Role, will create if not specified"
+  type        = string
+  default     = ""
+}
+
+#======================================================
+# AWS Firelens settings
+#======================================================
+variable "awsfirelens_enabled" {
+  description = "Whether to include the awsfirelens container in the task definition"
+  type        = bool
+  default     = false
+}
+
+variable "awsfirelens_image" {
+  description = "The full image for aws firelens, e.g. registry-host-name.com/repository/name:tag.  It is recommended to pin this to a specific tag for production systems vs relying on latest."
+  type        = string
+  default     = ""
+}
+
+variable "awsfirelens_cpu" {
+  description = "The amount of CPU to allocate to the AWS firelens container, in Mhz, e.g. 256"
+  type        = number
+  default     = null
+}
+
+variable "awsfirelens_memory" {
+  description = "The amount of Memory to allocate to the AWS firelens container, in MiB, e.g. 512"
+  type        = number
+  default     = null
+}
+
+variable "awsfirelens_host" {
+  description = "The hostname of the destination for awsfirelens to deliver logs to.  Example: logs-endpoint.example.com"
+  type        = string
+  default     = ""
+}
+
+variable "awsfirelens_uri" {
+  description = "The URI of the destination for awsfirelens to deliver logs to.  Example: /receiver/v1/http/<token>"
   type        = string
   default     = ""
 }

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -706,6 +706,14 @@ module "bigeye_admin" {
   rabbitmq_endpoint            = local.rabbitmq_endpoint
   rabbitmq_username            = var.rabbitmq_user_name
   rabbitmq_password_secret_arn = local.rabbitmq_user_password_secret_arn
+
+  # aws firelens
+  awsfirelens_cpu     = var.awsfirelens_cpu
+  awsfirelens_memory  = var.awsfirelens_memory
+  awsfirelens_enabled = var.awsfirelens_enabled
+  awsfirelens_host    = var.awsfirelens_host
+  awsfirelens_image   = var.awsfirelens_image
+  awsfirelens_uri     = var.awsfirelens_uri
 }
 
 #======================================================
@@ -929,6 +937,13 @@ module "haproxy" {
     BIGEYE_ADMIN_PAGES_PASSWORD = local.adminpages_password_secret_arn
   }
 
+  # aws firelens
+  awsfirelens_cpu     = var.awsfirelens_cpu
+  awsfirelens_memory  = var.awsfirelens_memory
+  awsfirelens_enabled = var.awsfirelens_enabled
+  awsfirelens_host    = var.awsfirelens_host
+  awsfirelens_image   = var.awsfirelens_image
+  awsfirelens_uri     = var.awsfirelens_uri
 
   environment_variables = merge(
     {
@@ -1015,6 +1030,13 @@ module "web" {
   datadog_agent_memory             = var.datadog_agent_memory
   datadog_agent_api_key_secret_arn = var.datadog_agent_api_key_secret_arn
 
+  # aws firelens
+  awsfirelens_cpu     = var.awsfirelens_cpu
+  awsfirelens_memory  = var.awsfirelens_memory
+  awsfirelens_enabled = var.awsfirelens_enabled
+  awsfirelens_host    = var.awsfirelens_host
+  awsfirelens_image   = var.awsfirelens_image
+  awsfirelens_uri     = var.awsfirelens_uri
 
   environment_variables = merge(
     local.web_dd_env_vars,
@@ -1233,6 +1255,13 @@ module "monocle" {
   datadog_agent_memory             = var.datadog_agent_memory
   datadog_agent_api_key_secret_arn = var.datadog_agent_api_key_secret_arn
 
+  # aws firelens
+  awsfirelens_cpu     = var.awsfirelens_cpu
+  awsfirelens_memory  = var.awsfirelens_memory
+  awsfirelens_enabled = var.awsfirelens_enabled
+  awsfirelens_host    = var.awsfirelens_host
+  awsfirelens_image   = var.awsfirelens_image
+  awsfirelens_uri     = var.awsfirelens_uri
 
   environment_variables = merge(
     {
@@ -1365,6 +1394,13 @@ module "toretto" {
   datadog_agent_memory             = var.datadog_agent_memory
   datadog_agent_api_key_secret_arn = var.datadog_agent_api_key_secret_arn
 
+  # aws firelens
+  awsfirelens_cpu     = var.awsfirelens_cpu
+  awsfirelens_memory  = var.awsfirelens_memory
+  awsfirelens_enabled = var.awsfirelens_enabled
+  awsfirelens_host    = var.awsfirelens_host
+  awsfirelens_image   = var.awsfirelens_image
+  awsfirelens_uri     = var.awsfirelens_uri
 
   environment_variables = merge(
     {
@@ -1526,6 +1562,13 @@ module "scheduler" {
   datadog_agent_memory             = var.datadog_agent_memory
   datadog_agent_api_key_secret_arn = var.datadog_agent_api_key_secret_arn
 
+  # aws firelens
+  awsfirelens_cpu     = var.awsfirelens_cpu
+  awsfirelens_memory  = var.awsfirelens_memory
+  awsfirelens_enabled = var.awsfirelens_enabled
+  awsfirelens_host    = var.awsfirelens_host
+  awsfirelens_image   = var.awsfirelens_image
+  awsfirelens_uri     = var.awsfirelens_uri
 
   environment_variables = merge(
     {
@@ -2030,6 +2073,14 @@ module "datawatch" {
   datadog_agent_memory             = var.datadog_agent_memory
   datadog_agent_api_key_secret_arn = var.datadog_agent_api_key_secret_arn
 
+  # aws firelens
+  awsfirelens_cpu     = var.awsfirelens_cpu
+  awsfirelens_memory  = var.awsfirelens_memory
+  awsfirelens_enabled = var.awsfirelens_enabled
+  awsfirelens_host    = var.awsfirelens_host
+  awsfirelens_image   = var.awsfirelens_image
+  awsfirelens_uri     = var.awsfirelens_uri
+
   environment_variables = merge(
     local.datawatch_dd_env_vars,
     local.datawatch_common_env_vars,
@@ -2095,6 +2146,14 @@ module "datawork" {
   datadog_agent_cpu                = var.datadog_agent_cpu
   datadog_agent_memory             = var.datadog_agent_memory
   datadog_agent_api_key_secret_arn = var.datadog_agent_api_key_secret_arn
+
+  # aws firelens
+  awsfirelens_cpu     = var.awsfirelens_cpu
+  awsfirelens_memory  = var.awsfirelens_memory
+  awsfirelens_enabled = var.awsfirelens_enabled
+  awsfirelens_host    = var.awsfirelens_host
+  awsfirelens_image   = var.awsfirelens_image
+  awsfirelens_uri     = var.awsfirelens_uri
 
   environment_variables = merge(
     local.datawatch_dd_env_vars,
@@ -2163,6 +2222,14 @@ module "lineagework" {
   datadog_agent_cpu                = var.datadog_agent_cpu
   datadog_agent_memory             = var.datadog_agent_memory
   datadog_agent_api_key_secret_arn = var.datadog_agent_api_key_secret_arn
+
+  # aws firelens
+  awsfirelens_cpu     = var.awsfirelens_cpu
+  awsfirelens_memory  = var.awsfirelens_memory
+  awsfirelens_enabled = var.awsfirelens_enabled
+  awsfirelens_host    = var.awsfirelens_host
+  awsfirelens_image   = var.awsfirelens_image
+  awsfirelens_uri     = var.awsfirelens_uri
 
   # lineagework should only subscribe to source-lineage and metacenter-lineage, ie exclude all other Temporal queues.
   environment_variables = merge(
@@ -2233,6 +2300,14 @@ module "metricwork" {
   datadog_agent_cpu                = var.datadog_agent_cpu
   datadog_agent_memory             = var.datadog_agent_memory
   datadog_agent_api_key_secret_arn = var.datadog_agent_api_key_secret_arn
+
+  # aws firelens
+  awsfirelens_cpu     = var.awsfirelens_cpu
+  awsfirelens_memory  = var.awsfirelens_memory
+  awsfirelens_enabled = var.awsfirelens_enabled
+  awsfirelens_host    = var.awsfirelens_host
+  awsfirelens_image   = var.awsfirelens_image
+  awsfirelens_uri     = var.awsfirelens_uri
 
   environment_variables = merge(
     local.datawatch_dd_env_vars,

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -277,6 +277,45 @@ variable "datadog_agent_api_key_secret_arn" {
 }
 
 #======================================================
+# AWS Firelens settings
+#======================================================
+variable "awsfirelens_enabled" {
+  description = "If set to true, container logs are shipped via AWS firelens and not cloudwatch.  The AWS firelens side car container though is the exception and will continue to send logs to cloudwatch logs even if var.awsfirelens_enabled = true to facilitate debugging firelens issues."
+  type        = bool
+  default     = false
+}
+
+variable "awsfirelens_image" {
+  description = "The full image for aws firelens, e.g. registry-host-name.com/repository/name:tag.  It is recommended to pin this to a specific tag for production systems vs relying on latest."
+  type        = string
+  default     = "amazon/aws-for-fluent-bit:latest"
+}
+
+variable "awsfirelens_cpu" {
+  description = "The amount of CPU to allocate to the AWS firelens container, in Mhz, e.g. 256"
+  type        = number
+  default     = 256
+}
+
+variable "awsfirelens_memory" {
+  description = "The amount of Memory to allocate to the AWS firelens container, in MiB, e.g. 512"
+  type        = number
+  default     = 256
+}
+
+variable "awsfirelens_host" {
+  description = "The hostname of the destination for awsfirelens to deliver logs to.  Example: logs-endpoint.example.com"
+  type        = string
+  default     = ""
+}
+
+variable "awsfirelens_uri" {
+  description = "The URI of the destination for awsfirelens to deliver logs to.  Example: /receiver/v1/http/<token>"
+  type        = string
+  default     = ""
+}
+
+#======================================================
 # Redis
 #======================================================
 variable "redis_extra_security_group_ids" {
@@ -731,13 +770,13 @@ variable "haproxy_desired_count" {
 variable "haproxy_cpu" {
   description = "Amount of CPU to allocate"
   type        = number
-  default     = 512
+  default     = 1024
 }
 
 variable "haproxy_memory" {
   description = "Amount of Memory in MB to allocate"
   type        = number
-  default     = 1024
+  default     = 2048
 }
 
 variable "haproxy_port" {
@@ -1869,13 +1908,13 @@ variable "scheduler_desired_count" {
 variable "scheduler_cpu" {
   description = "Amount of CPU to allocate"
   type        = number
-  default     = 512
+  default     = 1024
 }
 
 variable "scheduler_memory" {
   description = "Amount of Memory in MB to allocate"
   type        = number
-  default     = 1024
+  default     = 2048
 }
 
 variable "scheduler_port" {

--- a/modules/simpleservice/variables.tf
+++ b/modules/simpleservice/variables.tf
@@ -153,7 +153,7 @@ variable "docker_labels" {
 }
 
 variable "cloudwatch_log_group_name" {
-  description = "Cloudwatch log group name to write container logs"
+  description = "Cloudwatch log group name to write container logs.  If var.awsfirelens_enabled = true, container logs are shipped via AWS firelens and not cloudwatch.  The AWS firelens side car container though is the exception and will continue to send logs to cloudwatch logs even if var.awsfirelens_enabled = true to facilitate debugging firelens issues."
   type        = string
 }
 
@@ -230,6 +230,46 @@ variable "datadog_agent_additional_secret_arns" {
   type        = map(string)
   default     = {}
 }
+
+#======================================================
+# AWS Firelens settings
+#======================================================
+variable "awsfirelens_enabled" {
+  description = "Whether to include the awsfirelens container in the task definition"
+  type        = bool
+  default     = false
+}
+
+variable "awsfirelens_image" {
+  description = "The full image for aws firelens, e.g. registry-host-name.com/repository/name:tag.  It is recommended to pin this to a specific tag for production systems vs relying on latest."
+  type        = string
+  default     = ""
+}
+
+variable "awsfirelens_cpu" {
+  description = "The amount of CPU to allocate to the AWS firelens container, in Mhz, e.g. 256"
+  type        = number
+  default     = null
+}
+
+variable "awsfirelens_memory" {
+  description = "The amount of Memory to allocate to the AWS firelens container, in MiB, e.g. 512"
+  type        = number
+  default     = null
+}
+
+variable "awsfirelens_host" {
+  description = "The hostname of the destination for awsfirelens to deliver logs to.  Example: logs-endpoint.example.com"
+  type        = string
+  default     = ""
+}
+
+variable "awsfirelens_uri" {
+  description = "The URI of the destination for awsfirelens to deliver logs to.  Example: /receiver/v1/http/<token>"
+  type        = string
+  default     = ""
+}
+
 #======================================================
 # Load balancer settings
 #======================================================


### PR DESCRIPTION
Allow sending ECS logs via AWS firelens.  This opens the door for shipping logs to other log destinations besides Cloudwatch.