### PR TITLE
Fix self-managed-vpc-no-internet-access example install problems

### DIFF
--- a/examples/self-managed-vpc-no-internet-access/bring-your-own/ec2_bastion_example.tf
+++ b/examples/self-managed-vpc-no-internet-access/bring-your-own/ec2_bastion_example.tf
@@ -85,10 +85,18 @@ resource "aws_vpc_security_group_egress_rule" "egress" {
   ip_protocol       = "TCP"
 }
 
+data "aws_ami" "amazon_linux_2023" {
+  owners      = ["amazon"]
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+}
+
 resource "aws_instance" "bastion" {
-  count = var.bastion_enabled ? 1 : 0
-  # Amazon Linux 2023
-  ami                         = "ami-01cd4de4363ab6ee8"
+  count                       = var.bastion_enabled ? 1 : 0
+  ami                         = data.aws_ami.amazon_linux_2023.id
   instance_type               = "t3.small"
   key_name                    = aws_key_pair.bastion[0].key_name
   subnet_id                   = var.bastion_public ? module.vpc.public_subnets[0] : module.vpc.private_subnets[0]
@@ -100,7 +108,7 @@ resource "aws_instance" "bastion" {
     delete_on_termination = true
     encrypted             = true
     volume_type           = "gp3"
-    volume_size           = 10
+    volume_size           = 30
     tags = {
       Name = "Bigeye bastion"
     }


### PR DESCRIPTION
commit 918ae5c9938e8286e73c2329484130cc8f2170e5 (HEAD -> david/sre-3387-iqt-test-install-probs, origin/david/sre-3387-iqt-test-install-probs)
Author: David Nguyen <david@bigeye.com>
Date:   Tue Jun 4 16:39:32 2024 -0700

    docs: dynamically generate AMI name for self-managed-vpc-no-internet-access

    AMIs are Region specific, we need to generate the AMI dynamically
    for this example so that deployments to regions other than
    us-west-2 will be able to find the image.

commit b97208caf773749390bf575c2dc931e2da84856c
Author: David Nguyen <david@bigeye.com>
Date:   Tue Jun 4 16:37:35 2024 -0700

    docs: fix smtp VPCE subnet list for self-managed-vpc-no-internet-access

    Not all services have a VPCE in every AZ.  SES SMTP for example does
    not exist in us-east-1.

    Set this up to dynamically set the list of AZs based on those
    that are supported for SES.
