### PR TITLE
feat: add ability to mount EFS volume in app containers

### DIFF
--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -50,6 +50,24 @@ variable "execution_role_arn" {
   type        = string
 }
 
+variable "efs_volume_id" {
+  description = "Use in conjunction with var.access_point_id to mount an EFS volume on the app container"
+  type        = string
+  default     = ""
+}
+
+variable "efs_access_point_id" {
+  description = "Use in conjunction with var.efs_volume_id to mount an EFS volume on the app container"
+  type        = string
+  default     = ""
+}
+
+variable "efs_mount_point" {
+  description = "Container path where the EFS volume will be mounted."
+  type        = string
+  default     = ""
+}
+
 ### Info we need for environment variables
 variable "haproxy_domain_name" {
   description = "haproxy domain name"

--- a/modules/bigeye/efs.tf
+++ b/modules/bigeye/efs.tf
@@ -1,0 +1,112 @@
+resource "aws_security_group" "efs" {
+  count  = var.create_security_groups && local.efs_volume_enabled ? 1 : 0
+  name   = "${local.name}-efs"
+  vpc_id = local.vpc_id
+
+  tags = merge(local.tags, {
+    Name = local.name
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "efs" {
+  count             = var.create_security_groups && local.efs_volume_enabled ? 1 : 0
+  description       = "Allow NFS"
+  security_group_id = aws_security_group.efs[0].id
+  from_port         = 2049 # NFS
+  to_port           = 2049 # NFS
+  ip_protocol       = "TCP"
+  cidr_ipv4         = var.vpc_cidr_block
+}
+
+resource "aws_efs_file_system" "this" {
+  count           = local.efs_volume_enabled ? 1 : 0
+  throughput_mode = "elastic"
+  encrypted       = true
+  lifecycle_policy {
+    transition_to_ia = "AFTER_7_DAYS"
+  }
+  tags = merge(local.tags, {
+    Name = local.name
+  })
+}
+
+resource "aws_efs_file_system_policy" "this" {
+  count          = local.efs_volume_enabled ? 1 : 0
+  file_system_id = aws_efs_file_system.this[0].id
+  policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "allow-root-access",
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : "*"
+          },
+          "Action" : [
+            "elasticfilesystem:ClientRootAccess",
+            "elasticfilesystem:ClientWrite",
+            "elasticfilesystem:ClientMount"
+          ],
+          "Resource" : aws_efs_file_system.this[0].arn,
+          "Condition" : {
+            "Bool" : {
+              "elasticfilesystem:AccessedViaMountTarget" : "true"
+            }
+          }
+        },
+        {
+          "Sid" : "deny-unencrypted-transport",
+          "Effect" : "Deny",
+          "Principal" : {
+            "AWS" : "*"
+          },
+          "Action" : "*",
+          "Resource" : aws_efs_file_system.this[0].arn,
+          "Condition" : {
+            "Bool" : {
+              "aws:SecureTransport" : "false"
+            }
+          }
+        }
+      ]
+    }
+
+  )
+}
+
+resource "aws_efs_mount_target" "this" {
+  for_each        = local.efs_volume_enabled ? toset(local.application_subnet_ids) : []
+  file_system_id  = aws_efs_file_system.this[0].id
+  subnet_id       = each.value
+  security_groups = concat(var.efs_volume_extra_security_group_ids, [one(aws_security_group.efs[*].id)])
+}
+
+resource "aws_efs_access_point" "bigeye_admin" {
+  count          = local.efs_volume_enabled && var.enable_bigeye_admin_module ? 1 : 0
+  file_system_id = aws_efs_file_system.this[0].id
+  root_directory {
+    path = "/"
+  }
+  tags = merge(local.tags, {
+    Name = "${local.name}-bigeye-admin"
+    app  = "bigeye-admin"
+  })
+}
+
+resource "aws_efs_access_point" "this" {
+  for_each       = local.efs_volume_enabled ? toset(var.efs_volume_enabled_services) : []
+  file_system_id = aws_efs_file_system.this[0].id
+  root_directory {
+    creation_info {
+      owner_gid   = 0
+      owner_uid   = 0
+      permissions = "777"
+    }
+    path = "/${each.value}"
+  }
+  tags = merge(local.tags, {
+    Name = "${local.name}-${each.value}"
+    app  = each.value
+  })
+}

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -177,6 +177,7 @@ locals {
     },
     var.datawatch_additional_secret_arns,
   )
+  efs_volume_enabled = length(var.efs_volume_enabled_services) > 0
 
   temporal_lb_port                                     = 443
   temporal_per_namespace_worker_count                  = coalesce(var.temporal_per_namespace_worker_count, var.temporal_desired_count * 3)

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -243,6 +243,24 @@ variable "fargate_version" {
   default     = "1.4.0"
 }
 
+variable "efs_volume_enabled_services" {
+  description = "A shared EFS volume can be mounted on core service containers.  This can be useful for containers to persist a heap dump on OOM for example.  Service names: datawatch, datawork, metricwork, lineagework, etc"
+  type        = list(string)
+  default     = []
+}
+
+variable "efs_volume_extra_security_group_ids" {
+  description = "A list of additional security group ids to put onto the EFS volume"
+  type        = list(string)
+  default     = []
+}
+
+variable "efs_mount_point" {
+  description = "Container path where the EFS volume will be mounted."
+  type        = string
+  default     = "/mnt"
+}
+
 #======================================================
 # Datadog
 #======================================================

--- a/modules/simpleservice/containers.tf
+++ b/modules/simpleservice/containers.tf
@@ -19,8 +19,13 @@ locals {
       hostPort      = var.traffic_port
       protocol      = "tcp"
     }]
-    essential    = true
-    mountPoints  = []
+    essential = true
+    mountPoints = local.efs_volume_enabled ? [
+      {
+        containerPath : var.efs_mount_point,
+        sourceVolume : var.name,
+      }
+    ] : []
     volumesFrom  = []
     dockerLabels = merge(local.datadog_docker_labels, var.docker_labels)
     environment  = local.container_environment_variables

--- a/modules/simpleservice/variables.tf
+++ b/modules/simpleservice/variables.tf
@@ -186,6 +186,25 @@ variable "spot_weight" {
   type        = number
   default     = 0
 }
+
+variable "efs_volume_id" {
+  description = "Use in conjunction with var.access_point_id to mount an EFS volume on the app container"
+  type        = string
+  default     = ""
+}
+
+variable "efs_access_point_id" {
+  description = "Use in conjunction with var.efs_volume_id to mount an EFS volume on the app container"
+  type        = string
+  default     = ""
+}
+
+variable "efs_mount_point" {
+  description = "Container path where the EFS volume will be mounted."
+  type        = string
+  default     = ""
+}
+
 #======================================================
 # Datadog agent settings
 #======================================================


### PR DESCRIPTION
This is useful for debugging, like in the case where we would want to persist some generated data on instance stop like a heap dump.

A single EFS volume for the entire stack was chosen instead of volume per service as ECS containers can only allow 1 EFS volume mount, so with a single mount, all of the various container's EFS data can be read from the bigeye-admin container.

EFS access point per service gives us logical separation of data between the different services, so each service can only read/write its own data (except the admin container which can mount the root "/" so will see them all).

Also note it is not possible to disable AZ redundancy by using "one zone" mode to save on costs as we run into problems with EFS mount points not existing in the various AZ's since we don't allow constraining ECS tasks to a single AZ.