### PR TITLE
feat: enable heap dump on OOM for some java services

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2132,6 +2132,7 @@ module "datawatch" {
     {
       APP             = "datawatch"
       WORKERS_ENABLED = "false"
+      HEAP_DUMP_PATH  = contains(var.efs_volume_enabled_services, "datawatch") ? var.efs_mount_point : ""
     },
     var.datawatch_additional_environment_vars,
   )
@@ -2212,6 +2213,7 @@ module "datawork" {
       WORKERS_ENABLED    = "true"
       METRIC_RUN_WORKERS = "1"
       EXCLUDE_QUEUES     = "trigger-batch-metric-run,source-lineage,metacenter-lineage"
+      HEAP_DUMP_PATH     = contains(var.efs_volume_enabled_services, "datawork") ? var.efs_mount_point : ""
     },
     var.datawork_additional_environment_vars,
   )
@@ -2293,6 +2295,7 @@ module "lineagework" {
       METRIC_RUN_WORKERS = "1"
       EXCLUDE_QUEUES     = "run-metrics.v1,delete-source.v1,get-samples.v1,collect-lineage.v1,indexing.v1,reconciliation,trigger-batch-metric-run,agent-heartbeat"
       MQ_WORKERS_ENABLED = "false"
+      HEAP_DUMP_PATH     = contains(var.efs_volume_enabled_services, "lineagework") ? var.efs_mount_point : ""
     },
     var.lineagework_additional_environment_vars,
   )
@@ -2372,6 +2375,7 @@ module "metricwork" {
       WORKERS_ENABLED       = "true"
       METRIC_RUN_WORKERS    = "1"
       SINGLE_QUEUE_OVERRIDE = "trigger-batch-metric-run"
+      HEAP_DUMP_PATH        = contains(var.efs_volume_enabled_services, "metricwork") ? var.efs_mount_point : ""
     },
     var.metricwork_additional_environment_vars,
   )


### PR DESCRIPTION
This can be useful.  Enabling this if the EFS mount is available is quite lazy and a little roundabout.