### PR TITLE
fix: revert send monocle and toretto traffic to datawork instead

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1286,7 +1286,7 @@ module "monocle" {
       BACKLOG                    = "512"
       WORKERS                    = "2"
       TIMEOUT                    = "900"
-      DATAWATCH_ADDRESS          = "https://${local.datawork_dns_name}"
+      DATAWATCH_ADDRESS          = "https://${local.datawatch_dns_name}"
     },
     local.sentry_event_level_env_variable,
     var.datadog_agent_enabled ? {
@@ -1428,7 +1428,7 @@ module "toretto" {
       BACKLOG                    = "512"
       WORKERS                    = "1"
       TIMEOUT                    = "900"
-      DATAWATCH_ADDRESS          = "https://${local.datawork_dns_name}"
+      DATAWATCH_ADDRESS          = "https://${local.datawatch_dns_name}"
     },
     local.sentry_event_level_env_variable,
     var.toretto_additional_environment_vars,


### PR DESCRIPTION
This reverts commit cf4cf055d46fb86ad31586476d7f766dc786e4ae.

There are some undesirable side effects from this.  Go back to sending this traffic through datawatch until a dedicated internal API service is implemented.