### PR TITLE
feat: add private API service (papi) 1

### DIFF
--- a/modules/admin/main.tf
+++ b/modules/admin/main.tf
@@ -29,6 +29,7 @@ locals {
     DATAWORK_DOMAIN_NAME    = var.datawork_domain_name
     LINEAGEWORK_DOMAIN_NAME = var.lineagework_domain_name
     METRICWORK_DOMAIN_NAME  = var.metricwork_domain_name
+    PAPI_DOMAIN_NAME        = var.papi_domain_name
     SCHEDULER_DOMAIN_NAME   = var.scheduler_domain_name
 
     HAPROXY_ELB_NAME     = var.haproxy_resource_name
@@ -41,6 +42,7 @@ locals {
     DATAWORK_ELB_NAME    = var.datawork_resource_name
     LINEAGEWORK_ELB_NAME = var.lineagework_resource_name
     METRICWORK_ELB_NAME  = var.metricwork_resource_name
+    PAPI_ELB_NAME        = var.papi_resource_name
     SCHEDULER_ELB_NAME   = var.scheduler_resource_name
 
     HAPROXY_ECS_NAME     = var.haproxy_resource_name
@@ -53,6 +55,7 @@ locals {
     DATAWORK_ECS_NAME    = var.datawork_resource_name
     LINEAGEWORK_ECS_NAME = var.lineagework_resource_name
     METRICWORK_ECS_NAME  = var.metricwork_resource_name
+    PAPI_ECS_NAME        = var.papi_resource_name
     SCHEDULER_ECS_NAME   = var.scheduler_resource_name
 
     DATAWATCH_RDS_IDENTIFIER = var.datawatch_rds_identifier

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -119,6 +119,11 @@ variable "metricwork_domain_name" {
   type        = string
 }
 
+variable "papi_domain_name" {
+  description = "papi domain name"
+  type        = string
+}
+
 variable "scheduler_domain_name" {
   description = "scheduler domain name"
   type        = string
@@ -171,6 +176,11 @@ variable "lineagework_resource_name" {
 
 variable "metricwork_resource_name" {
   description = "metricwork resource name"
+  type        = string
+}
+
+variable "papi_resource_name" {
+  description = "papi resource name"
   type        = string
 }
 

--- a/modules/alarms/main.tf
+++ b/modules/alarms/main.tf
@@ -508,6 +508,32 @@ module "elb_metricwork" {
   error_rate_disabled    = true
 }
 
+module "elb_papi" {
+  source                         = "./elb"
+  stack                          = var.stack
+  app                            = "papi"
+  host_count_disabled            = var.elb_papi_host_count_disabled
+  host_count_datapoints_to_alarm = var.elb_papi_host_count_datapoints_to_alarm
+  host_count_evaluation_periods  = var.elb_papi_host_count_evaluation_periods
+  host_count_period              = var.elb_papi_host_count_period
+  host_count_sns_arns            = coalesce(var.elb_papi_host_count_sns_arns, [local.high_urgency_sns_topic_arn])
+  host_count_threshold           = var.elb_papi_host_count_threshold
+
+  response_time_disabled            = var.elb_papi_response_time_disabled
+  response_time_datapoints_to_alarm = var.elb_papi_response_time_datapoints_to_alarm
+  response_time_evaluation_periods  = var.elb_papi_response_time_evaluation_periods
+  response_time_period              = var.elb_papi_response_time_period
+  response_time_sns_arns            = coalesce(var.elb_papi_response_time_sns_arns, [local.low_urgency_sns_topic_arn])
+  response_time_threshold           = var.elb_papi_response_time_threshold
+
+  error_rate_disabled            = var.elb_papi_error_rate_disabled
+  error_rate_datapoints_to_alarm = var.elb_papi_error_rate_datapoints_to_alarm
+  error_rate_evaluation_periods  = var.elb_papi_error_rate_evaluation_periods
+  error_rate_period              = var.elb_papi_error_rate_period
+  error_rate_sns_arns            = coalesce(var.elb_papi_error_rate_sns_arns, [local.low_urgency_sns_topic_arn])
+  error_rate_threshold           = var.elb_papi_error_rate_threshold
+}
+
 module "elb_scheduler" {
   source                         = "./elb"
   stack                          = var.stack

--- a/modules/alarms/variables.tf
+++ b/modules/alarms/variables.tf
@@ -1589,6 +1589,114 @@ variable "elb_monocle_response_time_threshold" {
   default     = 120
 }
 
+variable "elb_papi_error_rate_datapoints_to_alarm" {
+  description = "The number of datapoints breaching threshold to alarm"
+  type        = number
+  default     = 3
+}
+
+variable "elb_papi_error_rate_disabled" {
+  description = "Whether to disable the specific alarm"
+  type        = bool
+  default     = false
+}
+
+variable "elb_papi_error_rate_evaluation_periods" {
+  description = "The number of periods over which the metric is evaluated"
+  type        = number
+  default     = 5
+}
+
+variable "elb_papi_error_rate_period" {
+  description = "The number of seconds over which the metric is evaluated"
+  type        = number
+  default     = 300
+}
+
+variable "elb_papi_error_rate_sns_arns" {
+  description = "The SNS topic arns to notify when the alarm fires"
+  type        = list(string)
+  default     = null
+}
+
+variable "elb_papi_error_rate_threshold" {
+  description = "Alarms when the metric is above this value"
+  type        = number
+  default     = 5
+}
+
+variable "elb_papi_host_count_datapoints_to_alarm" {
+  description = "The number of datapoints breaching threshold to alarm"
+  type        = number
+  default     = 3
+}
+
+variable "elb_papi_host_count_disabled" {
+  description = "Whether to disable the specific alarm"
+  type        = bool
+  default     = false
+}
+
+variable "elb_papi_host_count_evaluation_periods" {
+  description = "The number of periods over which the metric is evaluated"
+  type        = number
+  default     = 4
+}
+
+variable "elb_papi_host_count_period" {
+  description = "The number of seconds over which the metric is evaluated"
+  type        = number
+  default     = 900
+}
+
+variable "elb_papi_host_count_sns_arns" {
+  description = "The SNS topic arns to notify when the alarm fires"
+  type        = list(string)
+  default     = null
+}
+
+variable "elb_papi_host_count_threshold" {
+  description = "Alarms when the metric is below this value"
+  type        = number
+  default     = 0.5
+}
+
+variable "elb_papi_response_time_datapoints_to_alarm" {
+  description = "The number of datapoints breaching threshold to alarm"
+  type        = number
+  default     = 3
+}
+
+variable "elb_papi_response_time_disabled" {
+  description = "Whether to disable the specific alarm"
+  type        = bool
+  default     = false
+}
+
+variable "elb_papi_response_time_evaluation_periods" {
+  description = "The number of periods over which the metric is evaluated"
+  type        = number
+  default     = 4
+}
+
+variable "elb_papi_response_time_period" {
+  description = "The number of seconds over which the metric is evaluated"
+  type        = number
+  default     = 900
+}
+
+variable "elb_papi_response_time_sns_arns" {
+  description = "The SNS topic arns to notify when the alarm fires"
+  type        = list(string)
+  default     = null
+}
+
+variable "elb_papi_response_time_threshold" {
+  description = "Alarms when the metric is above this value"
+  type        = number
+  default     = 120
+}
+
 variable "elb_scheduler_error_rate_datapoints_to_alarm" {
   description = "The number of datapoints breaching threshold to alarm"
   type        = number

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -80,6 +80,7 @@ locals {
   datawork_dns_name                       = "${local.base_dns_alias}-datawork.${var.top_level_dns_name}"
   lineagework_dns_name                    = "${local.base_dns_alias}-lineagework.${var.top_level_dns_name}"
   metricwork_dns_name                     = "${local.base_dns_alias}-metricwork.${var.top_level_dns_name}"
+  papi_dns_name                           = "${local.base_dns_alias}-papi.${var.top_level_dns_name}"
   temporal_dns_name                       = "${local.base_dns_alias}-workflows.${var.top_level_dns_name}"
   temporalui_dns_name                     = "${local.base_dns_alias}-workflows-admin.${var.top_level_dns_name}"
   temporal_mysql_vanity_dns_name          = "${local.base_dns_alias}-temporal-mysql.${var.top_level_dns_name}"
@@ -130,6 +131,7 @@ locals {
   datawork_image_tag     = coalesce(var.datawork_image_tag, var.image_tag)
   lineagework_image_tag  = coalesce(var.lineagework_image_tag, var.image_tag)
   metricwork_image_tag   = coalesce(var.metricwork_image_tag, var.image_tag)
+  papi_image_tag         = coalesce(var.papi_image_tag, var.image_tag)
   scheduler_image_tag    = coalesce(var.scheduler_image_tag, var.image_tag)
   bigeye_admin_image_tag = coalesce(var.bigeye_admin_image_tag, var.image_tag)
 

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -159,6 +159,21 @@ output "monocle_load_balancer_zone_id" {
   value       = module.monocle.zone_id
 }
 
+output "papi_dns_name" {
+  description = "DNS name for the papi service"
+  value       = local.papi_dns_name
+}
+
+output "papi_load_balancer_dns_name" {
+  description = "The dns name of the papi load balancer"
+  value       = module.papi.dns_name
+}
+
+output "papi_load_balancer_zone_id" {
+  description = "The Route53 Zone ID of the papi load balancer"
+  value       = module.papi.zone_id
+}
+
 output "scheduler_dns_name" {
   description = "DNS name for the scheduler service"
   value       = local.scheduler_dns_name

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1909,6 +1909,63 @@ variable "metricwork_enable_ecs_exec" {
 }
 
 #======================================================
+# Application Variables - Papi
+#======================================================
+variable "papi_image_tag" {
+  description = "The image tag to use for papi, defaults to the global `image_tag` if not specified"
+  type        = string
+  default     = ""
+}
+
+variable "papi_desired_count" {
+  description = "The desired number of replicas"
+  type        = number
+  default     = 1
+}
+
+variable "papi_cpu" {
+  description = "Amount of CPU to allocate"
+  type        = number
+  default     = 1024
+}
+
+variable "papi_memory" {
+  description = "Amount of Memory in MB to allocate"
+  type        = number
+  default     = 4096
+}
+
+variable "papi_port" {
+  description = "The port to listen on"
+  type        = number
+  default     = 80
+}
+
+variable "papi_additional_environment_vars" {
+  description = "Additional enviromnent variables to give the application"
+  type        = map(string)
+  default     = {}
+}
+
+variable "papi_extra_security_group_ids" {
+  description = "Additional security group ids to papi"
+  type        = list(string)
+  default     = []
+}
+
+variable "papi_lb_extra_security_group_ids" {
+  description = "Additional security group ids to papi ALB"
+  type        = list(string)
+  default     = []
+}
+
+variable "papi_enable_ecs_exec" {
+  description = "Whether to enable ECS exec"
+  type        = bool
+  default     = false
+}
+
+#======================================================
 # Application Variables - Scheduler
 #======================================================
 variable "scheduler_image_tag" {


### PR DESCRIPTION
This service will handle intenal API requests.  This separates concerns of handling internal vs external requests on our API servers and will lead to better uptime and easier troubleshooting of user inititiated requests.

A followup task will route internal calls.  This gives installers a chance to install the service first before changing any call routing until the service is stable.