### PR TITLE
fix: datawatch KMS key fixups

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -176,8 +176,6 @@ locals {
       ROBOT_PASSWORD         = local.robot_password_secret_arn
       BASE_ENCRYPTION_SECRET = local.base_datawatch_encryption_secret_arn
       BASE_SALT              = local.base_datawatch_salt_secret_arn
-      KMS_KEY_ID             = aws_kms_key.datawatch.key_id
-      USE_KMS                = var.datwatch_encrypt_secrets_with_kms_enabled
     },
     var.datawatch_additional_secret_arns,
   )

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1817,6 +1817,34 @@ resource "aws_iam_role_policy" "datawatch_efs" {
   })
 }
 
+resource "aws_iam_role_policy" "datawatch_kms" {
+  count = local.create_datawatch_role && var.datwatch_encrypt_secrets_with_kms_enabled ? 1 : 0
+  role  = aws_iam_role.datawatch[0].id
+  name  = "AllowKMS"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "kms:DescribeKey",
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey*",
+          "kms:ReEncrypt*",
+
+        ],
+        "Resource" : aws_kms_key.datawatch[0].arn
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/stack" = local.name
+          }
+        }
+      }
+    ]
+  })
+}
+
 
 #======================================================
 # Datawatch - Redis

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1818,7 +1818,6 @@ resource "aws_iam_role_policy" "datawatch_efs" {
 }
 
 
-
 #======================================================
 # Datawatch - Redis
 #======================================================
@@ -2030,10 +2029,12 @@ resource "aws_secretsmanager_secret_version" "base_salt" {
   version_stages = ["AWSCURRENT"]
 }
 resource "aws_kms_alias" "encryption_key_alias" {
+  count         = var.datwatch_encrypt_secrets_with_kms_enabled ? 1 : 0
   name          = format("alias/bigeye/%s/datawatch", local.name)
-  target_key_id = aws_kms_key.datawatch.key_id
+  target_key_id = aws_kms_key.datawatch[0].key_id
 }
 resource "aws_kms_key" "datawatch" {
+  count               = var.datwatch_encrypt_secrets_with_kms_enabled ? 1 : 0
   description         = "KMS key that we use to encrypt/decrypt secrets. This will be used for securely storing sensitive information such as connection info. One will be created if not provided."
   enable_key_rotation = true
   # enable when we get past 5.33.0
@@ -2092,6 +2093,9 @@ locals {
 
     MTLS_KEY_PATH  = "/temporal/mtls.key"
     MTLS_CERT_PATH = "/temporal/mtls.pem"
+
+    USE_KMS    = var.datwatch_encrypt_secrets_with_kms_enabled
+    KMS_KEY_ID = var.datwatch_encrypt_secrets_with_kms_enabled ? aws_kms_key.datawatch[0].key_id : ""
   }
 }
 


### PR DESCRIPTION
commit 66da40f0cc38b88efd0bc159f85aee010d7b8249 (HEAD -> david/sre-3473-roll-out-kms-flags, origin/david/sre-3473-roll-out-kms-flags)
Author: David Nguyen <david@bigeye.com>
Date:   Wed Jun 26 15:11:30 2024 -0700

    fix: add permissions for datawatch ECS task to use KMS key

    The policy to allow datawatch to use the KMS key was
    missing.

commit 1aa302a5ff99671d0ece8f623c5061b50b08dd87
Author: David Nguyen <david@bigeye.com>
Date:   Wed Jun 26 14:43:55 2024 -0700

    fix: don't reference KMS unless feature is enabled

    The resources for this feature shouldn't be created or referenced
    unless the flag is turned on.

    They should also be passed to the app as normal env vars, not
    as AWS secrets manager secrets.