### PR TITLE
Breaking change: Autoscale papi service

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2477,7 +2477,7 @@ module "papi" {
   lb_subnet_ids                    = local.internal_service_alb_subnet_ids
   lb_additional_security_group_ids = concat(var.papi_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs      = var.internal_additional_ingress_cidrs
-  lb_deregistration_delay          = 900
+  lb_deregistration_delay          = 180
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2484,7 +2484,8 @@ module "papi" {
   lb_access_logs_bucket_prefix = format("%s-%s", local.elb_access_logs_prefix, "papi")
 
   # Task settings
-  desired_count             = var.papi_desired_count
+  control_desired_count     = var.papi_autoscaling_cpu_enabled ? false : true
+  desired_count             = var.papi_autoscaling_cpu_enabled ? 1 : var.papi_desired_count
   cpu                       = var.papi_cpu
   memory                    = var.papi_memory
   execution_role_arn        = local.ecs_role_arn
@@ -2524,4 +2525,31 @@ module "papi" {
   )
 
   secret_arns = local.datawatch_secret_arns
+}
+
+resource "aws_appautoscaling_target" "papi" {
+  count              = var.papi_autoscaling_cpu_enabled ? 1 : 0
+  depends_on         = [module.papi]
+  min_capacity       = 1
+  max_capacity       = var.papi_desired_count
+  resource_id        = format("service/%s/%s-papi", local.name, local.name)
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "papi" {
+  count              = var.papi_autoscaling_cpu_enabled ? 1 : 0
+  depends_on         = [aws_appautoscaling_target.papi]
+  name               = format("%s-papi-cpu", local.name)
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.papi[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.papi[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.papi[0].service_namespace
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+
+    target_value = var.papi_autoscaling_cpu_target
+  }
 }

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1924,9 +1924,9 @@ variable "papi_image_tag" {
 }
 
 variable "papi_desired_count" {
-  description = "The desired number of replicas"
+  description = "The desired number of replicas.  For autoscaling services, this becomes the max autoscaling capacity"
   type        = number
-  default     = 1
+  default     = 15
 }
 
 variable "papi_cpu" {
@@ -1971,6 +1971,17 @@ variable "papi_enable_ecs_exec" {
   default     = false
 }
 
+variable "papi_autoscaling_cpu_enabled" {
+  description = "Whether papi autoscaling is enabled. Note - if you change this variable, it changes the terraform resource that is created. You must run 'terraform state mv' in order to gracefully make this change"
+  type        = bool
+  default     = true
+}
+
+variable "papi_autoscaling_cpu_target" {
+  description = "% avg CPU util to use as autoscaling target"
+  type        = number
+  default     = 65
+}
 #======================================================
 # Application Variables - Scheduler
 #======================================================


### PR DESCRIPTION
commit 2067655b0361148239ce2a9d3fcd79181cbfb32d (HEAD -> david/sre-3475-autoscale-papi, origin/david/sre-3475-autoscale-papi)
Author: David Nguyen <david@bigeye.com>
Date:   Wed Jun 26 17:14:52 2024 -0700

    feat: reduce Papi ECS service deregistration delay to 3 minutes

    This service is responsible for handling what should be short lived
    requests.  Having a long deregistration delay is not ideal for
    autoscaling services as hung requests could stall scale-in.

commit c4f8c3ad42e23b462c1b80905646dee618eadfeb
Author: David Nguyen <david@bigeye.com>
Date:   Wed Jun 26 16:47:45 2024 -0700

    feat!: autoscale papi service

    This service fits naturally into a CPU autoscaling paradigm as it
    should be a CPU bound service that ramps up CPU util as the number of
    requests served by the individual instances ramps up.  Autoscaling
    here will save money and cover hot spots.

    BREAKING CHANGE: Upgrading to this version will result downtime while
    the Papi (internal API service) ECS service is replaced with an
    autoscaling version.  The downtime can be avoided by manually
    running a terraform state move before running terraform apply:

    terraform state mv \
    'module.bigeye.module.papi.aws_ecs_service.controlled_count[0]' \
    'module.bigeye.module.papi.aws_ecs_service.uncontrolled_count[0]'

    This also speeds up the terraform apply by ~15 minutes as that is
    the current LB deregistration delay on the Papi service.