### PR TITLE
fix: remove broken condition in kms policy

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2062,6 +2062,7 @@ resource "aws_kms_key" "datawatch" {
   enable_key_rotation = true
   # enable when we get past 5.33.0
   # rotation_period_in_days = 120
+  tags = merge(local.tags, { app = "datawatch" })
 }
 
 locals {

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1835,11 +1835,6 @@ resource "aws_iam_role_policy" "datawatch_kms" {
 
         ],
         "Resource" : aws_kms_key.datawatch[0].arn
-        Condition = {
-          StringEquals = {
-            "aws:ResourceTag/stack" = local.name
-          }
-        }
       }
     ]
   })


### PR DESCRIPTION
This condition was breaking permissions for the datawatch ECS service to access the KMS key.