### PR TITLE
fix: rename papi service to internalapi

### DIFF
--- a/modules/admin/main.tf
+++ b/modules/admin/main.tf
@@ -29,7 +29,7 @@ locals {
     DATAWORK_DOMAIN_NAME    = var.datawork_domain_name
     LINEAGEWORK_DOMAIN_NAME = var.lineagework_domain_name
     METRICWORK_DOMAIN_NAME  = var.metricwork_domain_name
-    PAPI_DOMAIN_NAME        = var.papi_domain_name
+    INTERNALAPI_DOMAIN_NAME = var.internalapi_domain_name
     SCHEDULER_DOMAIN_NAME   = var.scheduler_domain_name
 
     HAPROXY_ELB_NAME     = var.haproxy_resource_name
@@ -42,7 +42,7 @@ locals {
     DATAWORK_ELB_NAME    = var.datawork_resource_name
     LINEAGEWORK_ELB_NAME = var.lineagework_resource_name
     METRICWORK_ELB_NAME  = var.metricwork_resource_name
-    PAPI_ELB_NAME        = var.papi_resource_name
+    INTERNALAPI_ELB_NAME = var.internalapi_resource_name
     SCHEDULER_ELB_NAME   = var.scheduler_resource_name
 
     HAPROXY_ECS_NAME     = var.haproxy_resource_name
@@ -55,7 +55,7 @@ locals {
     DATAWORK_ECS_NAME    = var.datawork_resource_name
     LINEAGEWORK_ECS_NAME = var.lineagework_resource_name
     METRICWORK_ECS_NAME  = var.metricwork_resource_name
-    PAPI_ECS_NAME        = var.papi_resource_name
+    INTERNALAPI_ECS_NAME = var.internalapi_resource_name
     SCHEDULER_ECS_NAME   = var.scheduler_resource_name
 
     DATAWATCH_RDS_IDENTIFIER = var.datawatch_rds_identifier

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -119,8 +119,8 @@ variable "metricwork_domain_name" {
   type        = string
 }
 
-variable "papi_domain_name" {
-  description = "papi domain name"
+variable "internalapi_domain_name" {
+  description = "internalapi domain name"
   type        = string
 }
 
@@ -179,8 +179,8 @@ variable "metricwork_resource_name" {
   type        = string
 }
 
-variable "papi_resource_name" {
-  description = "papi resource name"
+variable "internalapi_resource_name" {
+  description = "internalapi resource name"
   type        = string
 }
 

--- a/modules/alarms/main.tf
+++ b/modules/alarms/main.tf
@@ -508,30 +508,30 @@ module "elb_metricwork" {
   error_rate_disabled    = true
 }
 
-module "elb_papi" {
+module "elb_internalapi" {
   source                         = "./elb"
   stack                          = var.stack
-  app                            = "papi"
-  host_count_disabled            = var.elb_papi_host_count_disabled
-  host_count_datapoints_to_alarm = var.elb_papi_host_count_datapoints_to_alarm
-  host_count_evaluation_periods  = var.elb_papi_host_count_evaluation_periods
-  host_count_period              = var.elb_papi_host_count_period
-  host_count_sns_arns            = coalesce(var.elb_papi_host_count_sns_arns, [local.high_urgency_sns_topic_arn])
-  host_count_threshold           = var.elb_papi_host_count_threshold
+  app                            = "internalapi"
+  host_count_disabled            = var.elb_internalapi_host_count_disabled
+  host_count_datapoints_to_alarm = var.elb_internalapi_host_count_datapoints_to_alarm
+  host_count_evaluation_periods  = var.elb_internalapi_host_count_evaluation_periods
+  host_count_period              = var.elb_internalapi_host_count_period
+  host_count_sns_arns            = coalesce(var.elb_internalapi_host_count_sns_arns, [local.high_urgency_sns_topic_arn])
+  host_count_threshold           = var.elb_internalapi_host_count_threshold
 
-  response_time_disabled            = var.elb_papi_response_time_disabled
-  response_time_datapoints_to_alarm = var.elb_papi_response_time_datapoints_to_alarm
-  response_time_evaluation_periods  = var.elb_papi_response_time_evaluation_periods
-  response_time_period              = var.elb_papi_response_time_period
-  response_time_sns_arns            = coalesce(var.elb_papi_response_time_sns_arns, [local.low_urgency_sns_topic_arn])
-  response_time_threshold           = var.elb_papi_response_time_threshold
+  response_time_disabled            = var.elb_internalapi_response_time_disabled
+  response_time_datapoints_to_alarm = var.elb_internalapi_response_time_datapoints_to_alarm
+  response_time_evaluation_periods  = var.elb_internalapi_response_time_evaluation_periods
+  response_time_period              = var.elb_internalapi_response_time_period
+  response_time_sns_arns            = coalesce(var.elb_internalapi_response_time_sns_arns, [local.low_urgency_sns_topic_arn])
+  response_time_threshold           = var.elb_internalapi_response_time_threshold
 
-  error_rate_disabled            = var.elb_papi_error_rate_disabled
-  error_rate_datapoints_to_alarm = var.elb_papi_error_rate_datapoints_to_alarm
-  error_rate_evaluation_periods  = var.elb_papi_error_rate_evaluation_periods
-  error_rate_period              = var.elb_papi_error_rate_period
-  error_rate_sns_arns            = coalesce(var.elb_papi_error_rate_sns_arns, [local.low_urgency_sns_topic_arn])
-  error_rate_threshold           = var.elb_papi_error_rate_threshold
+  error_rate_disabled            = var.elb_internalapi_error_rate_disabled
+  error_rate_datapoints_to_alarm = var.elb_internalapi_error_rate_datapoints_to_alarm
+  error_rate_evaluation_periods  = var.elb_internalapi_error_rate_evaluation_periods
+  error_rate_period              = var.elb_internalapi_error_rate_period
+  error_rate_sns_arns            = coalesce(var.elb_internalapi_error_rate_sns_arns, [local.low_urgency_sns_topic_arn])
+  error_rate_threshold           = var.elb_internalapi_error_rate_threshold
 }
 
 module "elb_scheduler" {
@@ -676,16 +676,16 @@ module "ecs_monocle" {
   mem_threshold           = var.ecs_monocle_mem_threshold
 }
 
-module "ecs_papi" {
+module "ecs_internalapi" {
   source                  = "./ecs"
   stack                   = var.stack
-  app                     = "monocle"
-  mem_disabled            = var.ecs_papi_mem_disabled
-  mem_datapoints_to_alarm = var.ecs_papi_mem_dataponts_to_alarm
-  mem_evaluation_periods  = var.ecs_papi_mem_evaluation_periods
-  mem_period              = var.ecs_papi_mem_period
-  mem_sns_arns            = coalesce(var.ecs_papi_mem_sns_arns, [local.low_urgency_sns_topic_arn])
-  mem_threshold           = var.ecs_papi_mem_threshold
+  app                     = "internalapi"
+  mem_disabled            = var.ecs_internalapi_mem_disabled
+  mem_datapoints_to_alarm = var.ecs_internalapi_mem_dataponts_to_alarm
+  mem_evaluation_periods  = var.ecs_internalapi_mem_evaluation_periods
+  mem_period              = var.ecs_internalapi_mem_period
+  mem_sns_arns            = coalesce(var.ecs_internalapi_mem_sns_arns, [local.low_urgency_sns_topic_arn])
+  mem_threshold           = var.ecs_internalapi_mem_threshold
 }
 
 module "ecs_scheduler" {

--- a/modules/alarms/variables.tf
+++ b/modules/alarms/variables.tf
@@ -1589,109 +1589,109 @@ variable "elb_monocle_response_time_threshold" {
   default     = 120
 }
 
-variable "elb_papi_error_rate_datapoints_to_alarm" {
+variable "elb_internalapi_error_rate_datapoints_to_alarm" {
   description = "The number of datapoints breaching threshold to alarm"
   type        = number
   default     = 3
 }
 
-variable "elb_papi_error_rate_disabled" {
+variable "elb_internalapi_error_rate_disabled" {
   description = "Whether to disable the specific alarm"
   type        = bool
   default     = false
 }
 
-variable "elb_papi_error_rate_evaluation_periods" {
+variable "elb_internalapi_error_rate_evaluation_periods" {
   description = "The number of periods over which the metric is evaluated"
   type        = number
   default     = 5
 }
 
-variable "elb_papi_error_rate_period" {
+variable "elb_internalapi_error_rate_period" {
   description = "The number of seconds over which the metric is evaluated"
   type        = number
   default     = 300
 }
 
-variable "elb_papi_error_rate_sns_arns" {
+variable "elb_internalapi_error_rate_sns_arns" {
   description = "The SNS topic arns to notify when the alarm fires"
   type        = list(string)
   default     = null
 }
 
-variable "elb_papi_error_rate_threshold" {
+variable "elb_internalapi_error_rate_threshold" {
   description = "Alarms when the metric is above this value"
   type        = number
   default     = 5
 }
 
-variable "elb_papi_host_count_datapoints_to_alarm" {
+variable "elb_internalapi_host_count_datapoints_to_alarm" {
   description = "The number of datapoints breaching threshold to alarm"
   type        = number
   default     = 3
 }
 
-variable "elb_papi_host_count_disabled" {
+variable "elb_internalapi_host_count_disabled" {
   description = "Whether to disable the specific alarm"
   type        = bool
   default     = false
 }
 
-variable "elb_papi_host_count_evaluation_periods" {
+variable "elb_internalapi_host_count_evaluation_periods" {
   description = "The number of periods over which the metric is evaluated"
   type        = number
   default     = 4
 }
 
-variable "elb_papi_host_count_period" {
+variable "elb_internalapi_host_count_period" {
   description = "The number of seconds over which the metric is evaluated"
   type        = number
   default     = 900
 }
 
-variable "elb_papi_host_count_sns_arns" {
+variable "elb_internalapi_host_count_sns_arns" {
   description = "The SNS topic arns to notify when the alarm fires"
   type        = list(string)
   default     = null
 }
 
-variable "elb_papi_host_count_threshold" {
+variable "elb_internalapi_host_count_threshold" {
   description = "Alarms when the metric is below this value"
   type        = number
   default     = 0.5
 }
 
-variable "elb_papi_response_time_datapoints_to_alarm" {
+variable "elb_internalapi_response_time_datapoints_to_alarm" {
   description = "The number of datapoints breaching threshold to alarm"
   type        = number
   default     = 3
 }
 
-variable "elb_papi_response_time_disabled" {
+variable "elb_internalapi_response_time_disabled" {
   description = "Whether to disable the specific alarm"
   type        = bool
   default     = false
 }
 
-variable "elb_papi_response_time_evaluation_periods" {
+variable "elb_internalapi_response_time_evaluation_periods" {
   description = "The number of periods over which the metric is evaluated"
   type        = number
   default     = 4
 }
 
-variable "elb_papi_response_time_period" {
+variable "elb_internalapi_response_time_period" {
   description = "The number of seconds over which the metric is evaluated"
   type        = number
   default     = 900
 }
 
-variable "elb_papi_response_time_sns_arns" {
+variable "elb_internalapi_response_time_sns_arns" {
   description = "The SNS topic arns to notify when the alarm fires"
   type        = list(string)
   default     = null
 }
 
-variable "elb_papi_response_time_threshold" {
+variable "elb_internalapi_response_time_threshold" {
   description = "Alarms when the metric is above this value"
   type        = number
   default     = 120
@@ -2345,37 +2345,37 @@ variable "ecs_monocle_mem_threshold" {
   default     = 70
 }
 
-variable "ecs_papi_mem_disabled" {
+variable "ecs_internalapi_mem_disabled" {
   description = "Whether to disable the specific alarm"
   type        = bool
   default     = false
 }
 
-variable "ecs_papi_mem_dataponts_to_alarm" {
+variable "ecs_internalapi_mem_dataponts_to_alarm" {
   description = "The number of datapoints breaching threshold to alarm"
   type        = number
   default     = 4
 }
 
-variable "ecs_papi_mem_evaluation_periods" {
+variable "ecs_internalapi_mem_evaluation_periods" {
   description = "The number of periods over which the metric is evaluated"
   type        = number
   default     = 5
 }
 
-variable "ecs_papi_mem_period" {
+variable "ecs_internalapi_mem_period" {
   description = "The number of seconds over which the metric is evaluated"
   type        = number
   default     = 300
 }
 
-variable "ecs_papi_mem_sns_arns" {
+variable "ecs_internalapi_mem_sns_arns" {
   description = "The SNS topic arns to notify when the alarm fires"
   type        = list(string)
   default     = null
 }
 
-variable "ecs_papi_mem_threshold" {
+variable "ecs_internalapi_mem_threshold" {
   description = "Alarms when the metric is above this value"
   type        = number
   default     = 70

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -82,7 +82,7 @@ locals {
   datawork_dns_name                       = "${local.base_dns_alias}-datawork.${var.top_level_dns_name}"
   lineagework_dns_name                    = "${local.base_dns_alias}-lineagework.${var.top_level_dns_name}"
   metricwork_dns_name                     = "${local.base_dns_alias}-metricwork.${var.top_level_dns_name}"
-  papi_dns_name                           = "${local.base_dns_alias}-papi.${var.top_level_dns_name}"
+  internalapi_dns_name                    = "${local.base_dns_alias}-internalapi.${var.top_level_dns_name}"
   temporal_dns_name                       = "${local.base_dns_alias}-workflows.${var.top_level_dns_name}"
   temporalui_dns_name                     = "${local.base_dns_alias}-workflows-admin.${var.top_level_dns_name}"
   temporal_mysql_vanity_dns_name          = "${local.base_dns_alias}-temporal-mysql.${var.top_level_dns_name}"
@@ -139,7 +139,7 @@ locals {
   datawork_image_tag     = coalesce(var.datawork_image_tag, var.image_tag)
   lineagework_image_tag  = coalesce(var.lineagework_image_tag, var.image_tag)
   metricwork_image_tag   = coalesce(var.metricwork_image_tag, var.image_tag)
-  papi_image_tag         = coalesce(var.papi_image_tag, var.image_tag)
+  internalapi_image_tag  = coalesce(var.internalapi_image_tag, var.image_tag)
   scheduler_image_tag    = coalesce(var.scheduler_image_tag, var.image_tag)
   bigeye_admin_image_tag = coalesce(var.bigeye_admin_image_tag, var.image_tag)
 

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -159,19 +159,19 @@ output "monocle_load_balancer_zone_id" {
   value       = module.monocle.zone_id
 }
 
-output "papi_dns_name" {
-  description = "DNS name for the papi service"
-  value       = local.papi_dns_name
+output "internalapi_dns_name" {
+  description = "DNS name for the internalapi service"
+  value       = local.internalapi_dns_name
 }
 
-output "papi_load_balancer_dns_name" {
-  description = "The dns name of the papi load balancer"
-  value       = module.papi.dns_name
+output "internalapi_load_balancer_dns_name" {
+  description = "The dns name of the internalapi load balancer"
+  value       = module.internalapi.dns_name
 }
 
-output "papi_load_balancer_zone_id" {
-  description = "The Route53 Zone ID of the papi load balancer"
-  value       = module.papi.zone_id
+output "internalapi_load_balancer_zone_id" {
+  description = "The Route53 Zone ID of the internalapi load balancer"
+  value       = module.internalapi.zone_id
 }
 
 output "scheduler_dns_name" {

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1939,69 +1939,69 @@ variable "metricwork_enable_ecs_exec" {
 }
 
 #======================================================
-# Application Variables - Papi
+# Application Variables - internalapi
 #======================================================
-variable "papi_image_tag" {
-  description = "The image tag to use for papi, defaults to the global `image_tag` if not specified"
+variable "internalapi_image_tag" {
+  description = "The image tag to use for internalapi, defaults to the global `image_tag` if not specified"
   type        = string
   default     = ""
 }
 
-variable "papi_desired_count" {
+variable "internalapi_desired_count" {
   description = "The desired number of replicas.  For autoscaling services, this becomes the max autoscaling capacity"
   type        = number
   default     = 15
 }
 
-variable "papi_cpu" {
+variable "internalapi_cpu" {
   description = "Amount of CPU to allocate"
   type        = number
   default     = 1024
 }
 
-variable "papi_memory" {
+variable "internalapi_memory" {
   description = "Amount of Memory in MB to allocate"
   type        = number
   default     = 4096
 }
 
-variable "papi_port" {
+variable "internalapi_port" {
   description = "The port to listen on"
   type        = number
   default     = 80
 }
 
-variable "papi_additional_environment_vars" {
+variable "internalapi_additional_environment_vars" {
   description = "Additional enviromnent variables to give the application"
   type        = map(string)
   default     = {}
 }
 
-variable "papi_extra_security_group_ids" {
-  description = "Additional security group ids to papi"
+variable "internalapi_extra_security_group_ids" {
+  description = "Additional security group ids to internalapi"
   type        = list(string)
   default     = []
 }
 
-variable "papi_lb_extra_security_group_ids" {
-  description = "Additional security group ids to papi ALB"
+variable "internalapi_lb_extra_security_group_ids" {
+  description = "Additional security group ids to internalapi ALB"
   type        = list(string)
   default     = []
 }
 
-variable "papi_enable_ecs_exec" {
+variable "internalapi_enable_ecs_exec" {
   description = "Whether to enable ECS exec"
   type        = bool
   default     = false
 }
 
-variable "papi_autoscaling_cpu_enabled" {
-  description = "Whether papi autoscaling is enabled. Note - if you change this variable, it changes the terraform resource that is created. You must run 'terraform state mv' in order to gracefully make this change"
+variable "internalapi_autoscaling_cpu_enabled" {
+  description = "Whether internalapi autoscaling is enabled. Note - if you change this variable, it changes the terraform resource that is created. You must run 'terraform state mv' in order to gracefully make this change"
   type        = bool
   default     = true
 }
 
-variable "papi_autoscaling_cpu_target" {
+variable "internalapi_autoscaling_cpu_target" {
   description = "% avg CPU util to use as autoscaling target"
   type        = number
   default     = 65


### PR DESCRIPTION
papi (private api) ended up not being a popular name internally, so it is being renamed to internalapi.  It was a thought to support the existing variable names and avoid the breaking change, but it will keep the house much cleaner if we just take the breaking change and remove them.

BREAKING CHANGE: All variables with papi in the name need to be globally replaced with internalwatch.