### PR TITLE
feat: add env vars to control job executor parallelism

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2293,12 +2293,24 @@ module "datawork" {
     local.datawatch_dd_env_vars,
     local.datawatch_common_env_vars,
     {
-      APP                = "datawork"
-      DATAWATCH_ADDRESS  = "http://localhost:${var.datawork_port}"
-      WORKERS_ENABLED    = "true"
-      METRIC_RUN_WORKERS = "1"
-      EXCLUDE_QUEUES     = "trigger-batch-metric-run,source-lineage,metacenter-lineage"
-      HEAP_DUMP_PATH     = contains(var.efs_volume_enabled_services, "datawork") ? var.efs_mount_point : ""
+      APP                              = "datawork"
+      DATAWATCH_ADDRESS                = "http://localhost:${var.datawork_port}"
+      WORKERS_ENABLED                  = "true"
+      METRIC_RUN_WORKERS               = "1"
+      EXCLUDE_QUEUES                   = "trigger-batch-metric-run,source-lineage,metacenter-lineage"
+      HEAP_DUMP_PATH                   = contains(var.efs_volume_enabled_services, "datawork") ? var.efs_mount_point : ""
+      RUN_METRICS_WF_EXEC_SIZE         = var.temporal_client_run_metrics_wf_exec_size
+      RUN_METRICS_ACT_EXEC_SIZE        = var.temporal_client_run_metrics_act_exec_size
+      DELETE_SOURCE_WF_EXEC_SIZE       = var.temporal_client_delete_source_wf_exec_size
+      DELETE_SOURCE_ACT_EXEC_SIZE      = var.temporal_client_delete_source_act_exec_size
+      GET_SAMPLES_WF_EXEC_SIZE         = var.temporal_client_get_samples_wf_exec_size
+      GET_SAMPLES_ACT_EXEC_SIZE        = var.temporal_client_get_samples_act_exec_size
+      INDEXING_WF_EXEC_SIZE            = var.temporal_client_indexing_wf_exec_size
+      INDEXING_ACT_EXEC_SIZE           = var.temporal_client_indexing_act_exec_size
+      RECONCILIATION_WF_EXEC_SIZE      = var.temporal_client_reconciliation_wf_exec_size
+      RECONCILIATION_ACT_EXEC_SIZE     = var.temporal_client_reconciliation_act_exec_size
+      REFRESH_SCORECARDS_WF_EXEC_SIZE  = var.temporal_client_refresh_scorecard_wf_exec_size
+      REFRESH_SCORECARDS_ACT_EXEC_SIZE = var.temporal_client_refresh_scorecard_act_exec_size
     },
     var.datawork_additional_environment_vars,
   )
@@ -2374,13 +2386,17 @@ module "lineagework" {
     local.datawatch_dd_env_vars,
     local.datawatch_common_env_vars,
     {
-      APP                = "lineagework"
-      DATAWATCH_ADDRESS  = "http://localhost:${var.lineagework_port}"
-      WORKERS_ENABLED    = "true"
-      METRIC_RUN_WORKERS = "1"
-      EXCLUDE_QUEUES     = "run-metrics.v1,delete-source.v1,get-samples.v1,collect-lineage.v1,indexing.v1,reconciliation,trigger-batch-metric-run,agent-heartbeat"
-      MQ_WORKERS_ENABLED = "false"
-      HEAP_DUMP_PATH     = contains(var.efs_volume_enabled_services, "lineagework") ? var.efs_mount_point : ""
+      APP                          = "lineagework"
+      DATAWATCH_ADDRESS            = "http://localhost:${var.lineagework_port}"
+      WORKERS_ENABLED              = "true"
+      METRIC_RUN_WORKERS           = "1"
+      EXCLUDE_QUEUES               = "run-metrics.v1,delete-source.v1,get-samples.v1,collect-lineage.v1,indexing.v1,reconciliation,trigger-batch-metric-run,agent-heartbeat,refresh-scorecards"
+      MQ_WORKERS_ENABLED           = "false"
+      HEAP_DUMP_PATH               = contains(var.efs_volume_enabled_services, "lineagework") ? var.efs_mount_point : ""
+      SOURCE_LINEAGE_WF_EXEC_SIZE  = var.temporal_client_source_lineage_wf_exec_size
+      SOURCE_LINEAGE_ACT_EXEC_SIZE = var.temporal_client_source_lineage_act_exec_size
+      MC_LINEAGE_WF_EXEC_SIZE      = var.temporal_client_mc_lineage_wf_exec_size
+      MC_LINEAGE_ACT_EXEC_SIZE     = var.temporal_client_mc_lineage_act_exec_size
     },
     var.lineagework_additional_environment_vars,
   )
@@ -2455,12 +2471,14 @@ module "metricwork" {
     local.datawatch_dd_env_vars,
     local.datawatch_common_env_vars,
     {
-      APP                   = "metricwork"
-      DATAWATCH_ADDRESS     = "http://localhost:${var.metricwork_port}"
-      WORKERS_ENABLED       = "true"
-      METRIC_RUN_WORKERS    = "1"
-      SINGLE_QUEUE_OVERRIDE = "trigger-batch-metric-run"
-      HEAP_DUMP_PATH        = contains(var.efs_volume_enabled_services, "metricwork") ? var.efs_mount_point : ""
+      APP                                    = "metricwork"
+      DATAWATCH_ADDRESS                      = "http://localhost:${var.metricwork_port}"
+      WORKERS_ENABLED                        = "true"
+      METRIC_RUN_WORKERS                     = "1"
+      SINGLE_QUEUE_OVERRIDE                  = "trigger-batch-metric-run"
+      HEAP_DUMP_PATH                         = contains(var.efs_volume_enabled_services, "metricwork") ? var.efs_mount_point : ""
+      TRIGGER_BATCH_METRIC_RUN_WF_EXEC_SIZE  = var.temporal_client_trigger_batch_metric_run_wf_exec_size
+      TRIGGER_BATCH_METRIC_RUN_ACT_EXEC_SIZE = var.temporal_client_trigger_batch_metric_run_act_exec_size
     },
     var.metricwork_additional_environment_vars,
   )

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1349,6 +1349,118 @@ variable "temporal_system_visibility_persistence_max_write_qps" {
 }
 
 #======================================================
+# Application Variables - Temporal Clients (job executor)
+#======================================================
+variable "temporal_client_run_metrics_wf_exec_size" {
+  description = "Controls run-metrics.v1 workflow execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_run_metrics_act_exec_size" {
+  description = "Controls run-metrics.v1 activity execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_delete_source_wf_exec_size" {
+  description = "Controls delete-source.v1 workflow execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_delete_source_act_exec_size" {
+  description = "Controls delete-source.v1 activity execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_get_samples_wf_exec_size" {
+  description = "Controls get-samples.v1 workflow execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_get_samples_act_exec_size" {
+  description = "Controls get-samples.v1 activity execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_indexing_wf_exec_size" {
+  description = "Controls indexing.v1 workflow execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_indexing_act_exec_size" {
+  description = "Controls indexing.v1 activity execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_reconciliation_wf_exec_size" {
+  description = "Controls reconciliation workflow execution thread count.  This is used for reconciling metric run schedules."
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_reconciliation_act_exec_size" {
+  description = "Controls reconciliation activity execution thread count.  This is used for reconciling metric run schedules."
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_trigger_batch_metric_run_wf_exec_size" {
+  description = "Controls trigger-batch-metric-run workflow execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_trigger_batch_metric_run_act_exec_size" {
+  description = "Controls trigger-batch-metric-run activity execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_source_lineage_wf_exec_size" {
+  description = "Controls source-lineage workflow execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_source_lineage_act_exec_size" {
+  description = "Controls source-lineage activity execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_mc_lineage_wf_exec_size" {
+  description = "Controls metacenter-lineage workflow execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_mc_lineage_act_exec_size" {
+  description = "Controls metacenter-lineage activity execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_refresh_scorecard_wf_exec_size" {
+  description = "Controls refresh-scorecards workflow execution thread count.  This is used for refreshing data used in scorecards."
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_refresh_scorecard_act_exec_size" {
+  description = "Controls refresh-scorecards activity execution thread count.  This is used for refreshing data used in scorecards."
+  type        = number
+  default     = 200
+}
+
+
+#======================================================
 # Application Variables - Datawatch
 #======================================================
 variable "datawatch_image_tag" {


### PR DESCRIPTION
The job runners can consume too much cpu/mem as the defaults are for 200 parallel threads.  These environment variables allow fine grained control over all of the Temporal based work queues.

I opted for a generic name on the TF variables as the queue membership can be fluid and would become breaking changes if we moved queue subscription around to different services