### PR TITLE
fix: reduce default value for scorecard refresh parallelism

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1450,7 +1450,7 @@ variable "temporal_client_mc_lineage_act_exec_size" {
 variable "temporal_client_refresh_scorecard_wf_exec_size" {
   description = "Controls refresh-scorecards workflow execution thread count.  This is used for refreshing data used in scorecards."
   type        = number
-  default     = 200
+  default     = 5
 }
 
 variable "temporal_client_refresh_scorecard_act_exec_size" {


### PR DESCRIPTION
This is a chunky workflow that consumes too much CPU per node due with the default number of parallel threads (200).  5 ends up being between 1-2 CPU which is very reasonable for most installs.