### PR TITLE
feat: change autothreshold S3 file expiration to 45 days

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -818,7 +818,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "models" {
     id     = "ExpireOldModels"
     status = "Enabled"
     expiration {
-      days = 30
+      days = 45
     }
   }
 }


### PR DESCRIPTION
This is useful for forensics and debugging to retain the models longer than 1 month as some autothreshold problems can take a long time to surface.