### PR TITLE
chore: remove FF_JVM_MEMORY_LEAK_FIX_ENABLED environment variable

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2120,7 +2120,6 @@ locals {
     FF_ANALYTICS_LOGGING_ENABLED    = var.datawatch_feature_analytics_logging_enabled
     FF_QUEUE_BACKFILL_ENABLED       = "true"
     FF_SEND_ANALYTICS_ENABLED       = var.datawatch_feature_analytics_send_enabled
-    FF_JVM_MEMORY_LEAK_FIX_ENABLED  = var.datawatch_feature_jvm_memory_leak_fix
     REQUEST_AUTH_LOGGING_ENABLED    = var.datawatch_request_auth_logging_enabled
     REQUEST_BODY_LOGGING_ENABLED    = var.datawatch_request_body_logging_enabled
 

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1856,11 +1856,10 @@ variable "datawatch_feature_analytics_send_enabled" {
 }
 
 variable "datawatch_feature_jvm_memory_leak_fix" {
-  description = "This flag can be set to true to turn on a JVM option to resolve a memory leak"
+  description = "DEPRECATED: This flag no longer does anything.  It will be removed in a future release"
   type        = bool
   default     = false
 }
-
 
 variable "datawatch_request_body_logging_enabled" {
   description = "Whether request body logs are enabled"


### PR DESCRIPTION
This flag is no longer needed, the memory leak fix is part of the code as of 1.65.0-hotfix.1 and os not configurable anymore.