### PR TITLE
feat: add enable flag for logging class load/unload messages

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2122,6 +2122,7 @@ locals {
     FF_SEND_ANALYTICS_ENABLED       = var.datawatch_feature_analytics_send_enabled
     REQUEST_AUTH_LOGGING_ENABLED    = var.datawatch_request_auth_logging_enabled
     REQUEST_BODY_LOGGING_ENABLED    = var.datawatch_request_body_logging_enabled
+    CLASS_LOADING_LOGGING_ENABLED   = var.datawatch_class_loading_logging_enabled
 
     AUTH0_DOMAIN            = var.auth0_domain
     EXTERNAL_LOGGING_LEVEL  = var.datawatch_external_logging_level

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1873,6 +1873,12 @@ variable "datawatch_request_auth_logging_enabled" {
   default     = false
 }
 
+variable "datawatch_class_loading_logging_enabled" {
+  description = "Verbose debug logging of every class load/unload event.  This is useful to trace out of memory due to compressed class space exhaustion.  Not recommended to set to true for production"
+  type        = bool
+  default     = false
+}
+
 variable "datawatch_stitch_schema_name" {
   description = "stitch schema name"
   type        = string


### PR DESCRIPTION
These are useful for tracing out of memory due to compressed class space exhaustion.