### PR TITLE
feat: use an include queue list instead of exclude queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ to the value of the `image_tag`, specifying the application image.
 It is always recommended to be on the latest
 terraform version and application version.
 
-| terraform-modules Version | Application Version | Comment |
-| ----------------- | ------------------- | ------- |
-| >= 9.2.0 | 1.65.0 | mTLS support in datawatch services removed, requires TF settings introduced in `9.2.0` |
-| 9.2.0 | >= 1.57.0 | TF adds temporal settings that were released in app version 1.57.0 |
-| >= 3.12.0 | 1.48.0 | Application 1.48.0 requires at least terraform-modules version 3.12.0 |
+| terraform-modules Version | Application Version | Comment                                                                                  |
+|---------------------------|-----------|------------------------------------------------------------------------------------------|
+| >= 11.4.0                 | 1.71.0    | migrate queue membership to "include" list that became available in app version `1.71.0` |
+| >= 9.2.0                  | 1.65.0    | mTLS support in datawatch services removed, requires TF settings introduced in `9.2.0`   |
+| 9.2.0                     | >= 1.57.0 | TF adds temporal settings that were released in app version 1.57.0                       |
+| >= 3.12.0                 | 1.48.0    | Application 1.48.0 requires at least terraform-modules version 3.12.0                    |
 
 ## Upgrading
 

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2382,7 +2382,6 @@ module "lineagework" {
   awsfirelens_image   = var.awsfirelens_image
   awsfirelens_uri     = var.awsfirelens_uri
 
-  # lineagework should only subscribe to source-lineage and metacenter-lineage, ie exclude all other Temporal queues.
   environment_variables = merge(
     local.datawatch_dd_env_vars,
     local.datawatch_common_env_vars,
@@ -2392,7 +2391,7 @@ module "lineagework" {
       WORKERS_ENABLED              = "true"
       MAX_RAM_PERCENTAGE           = var.lineagework_jvm_max_ram_pct
       METRIC_RUN_WORKERS           = "1"
-      EXCLUDE_QUEUES               = "run-metrics.v1,delete-source.v1,get-samples.v1,collect-lineage.v1,indexing.v1,reconciliation,trigger-batch-metric-run,agent-heartbeat,refresh-scorecards,monocle-invalidation,issue-root-cause"
+      INCLUDE_QUEUES               = "source-lineage,metacenter-lineage"
       MQ_WORKERS_ENABLED           = "false"
       HEAP_DUMP_PATH               = contains(var.efs_volume_enabled_services, "lineagework") ? var.efs_mount_point : ""
       SOURCE_LINEAGE_WF_EXEC_SIZE  = var.temporal_client_source_lineage_wf_exec_size
@@ -2478,7 +2477,7 @@ module "metricwork" {
       WORKERS_ENABLED                        = "true"
       MAX_RAM_PERCENTAGE                     = var.metricwork_jvm_max_ram_pct
       METRIC_RUN_WORKERS                     = "1"
-      SINGLE_QUEUE_OVERRIDE                  = "trigger-batch-metric-run"
+      INCLUDE_QUEUES                         = "trigger-batch-metric-run"
       HEAP_DUMP_PATH                         = contains(var.efs_volume_enabled_services, "metricwork") ? var.efs_mount_point : ""
       TRIGGER_BATCH_METRIC_RUN_WF_EXEC_SIZE  = var.temporal_client_trigger_batch_metric_run_wf_exec_size
       TRIGGER_BATCH_METRIC_RUN_ACT_EXEC_SIZE = var.temporal_client_trigger_batch_metric_run_act_exec_size


### PR DESCRIPTION
There is a new feature in datawatch and related services to allow an include list.  Using this removes the maintenance task of needing to maintain the exclude list everytime a new queue is added to temporal.

Also convert metricwork over to use this instead of the single queue override.  That feature is (or should be) deprecated and removed since we now have an include list.

This shouldn't be merged until 1.71.0 is released.