### PR TITLE
feat: add indexwork service

### DIFF
--- a/modules/admin/main.tf
+++ b/modules/admin/main.tf
@@ -27,6 +27,7 @@ locals {
     TEMPORALUI_DOMAIN_NAME  = var.temporalui_domain_name
     DATAWATCH_DOMAIN_NAME   = var.datawatch_domain_name
     DATAWORK_DOMAIN_NAME    = var.datawork_domain_name
+    INDEXWORK_DOMAIN_NAME   = var.indexwork_domain_name
     LINEAGEWORK_DOMAIN_NAME = var.lineagework_domain_name
     METRICWORK_DOMAIN_NAME  = var.metricwork_domain_name
     INTERNALAPI_DOMAIN_NAME = var.internalapi_domain_name
@@ -40,6 +41,7 @@ locals {
     TEMPORALUI_ELB_NAME  = var.temporalui_resource_name
     DATAWATCH_ELB_NAME   = var.datawatch_resource_name
     DATAWORK_ELB_NAME    = var.datawork_resource_name
+    INDEXWORK_ELB_NAME   = var.indexwork_resource_name
     LINEAGEWORK_ELB_NAME = var.lineagework_resource_name
     METRICWORK_ELB_NAME  = var.metricwork_resource_name
     INTERNALAPI_ELB_NAME = var.internalapi_resource_name
@@ -53,6 +55,7 @@ locals {
     TEMPORALUI_ECS_NAME  = var.temporalui_resource_name
     DATAWATCH_ECS_NAME   = var.datawatch_resource_name
     DATAWORK_ECS_NAME    = var.datawork_resource_name
+    INDEXWORK_ECS_NAME   = var.indexwork_resource_name
     LINEAGEWORK_ECS_NAME = var.lineagework_resource_name
     METRICWORK_ECS_NAME  = var.metricwork_resource_name
     INTERNALAPI_ECS_NAME = var.internalapi_resource_name

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -109,6 +109,11 @@ variable "datawork_domain_name" {
   type        = string
 }
 
+variable "indexwork_domain_name" {
+  description = "indexwork domain name"
+  type        = string
+}
+
 variable "lineagework_domain_name" {
   description = "lineagework domain name"
   type        = string
@@ -166,6 +171,11 @@ variable "datawatch_resource_name" {
 
 variable "datawork_resource_name" {
   description = "datawork resource name"
+  type        = string
+}
+
+variable "indexwork_resource_name" {
+  description = "indexwork resource name"
   type        = string
 }
 

--- a/modules/alarms/main.tf
+++ b/modules/alarms/main.tf
@@ -478,6 +478,21 @@ module "elb_datawork" {
   error_rate_disabled    = true
 }
 
+module "elb_indexwork" {
+  source                         = "./elb"
+  stack                          = var.stack
+  app                            = "indexwork"
+  host_count_disabled            = var.elb_indexwork_host_count_disabled
+  host_count_datapoints_to_alarm = var.elb_indexwork_host_count_datapoints_to_alarm
+  host_count_evaluation_periods  = var.elb_indexwork_host_count_evaluation_periods
+  host_count_period              = var.elb_indexwork_host_count_period
+  host_count_sns_arns            = coalesce(var.elb_indexwork_host_count_sns_arns, [local.high_urgency_sns_topic_arn])
+  host_count_threshold           = var.elb_indexwork_host_count_threshold
+
+  response_time_disabled = true
+  error_rate_disabled    = true
+}
+
 module "elb_lineagework" {
   source                         = "./elb"
   stack                          = var.stack
@@ -638,6 +653,18 @@ module "ecs_datawork" {
   mem_period              = var.ecs_datawork_mem_period
   mem_sns_arns            = coalesce(var.ecs_datawork_mem_sns_arns, [local.low_urgency_sns_topic_arn])
   mem_threshold           = var.ecs_datawork_mem_threshold
+}
+
+module "ecs_indexwork" {
+  source                  = "./ecs"
+  stack                   = var.stack
+  app                     = "indexwork"
+  mem_disabled            = var.ecs_indexwork_mem_disabled
+  mem_datapoints_to_alarm = var.ecs_indexwork_mem_dataponts_to_alarm
+  mem_evaluation_periods  = var.ecs_indexwork_mem_evaluation_periods
+  mem_period              = var.ecs_indexwork_mem_period
+  mem_sns_arns            = coalesce(var.ecs_indexwork_mem_sns_arns, [local.low_urgency_sns_topic_arn])
+  mem_threshold           = var.ecs_indexwork_mem_threshold
 }
 
 module "ecs_lineagework" {

--- a/modules/alarms/variables.tf
+++ b/modules/alarms/variables.tf
@@ -1409,6 +1409,42 @@ variable "elb_haproxy_response_time_threshold" {
   default     = 120
 }
 
+variable "elb_indexwork_host_count_datapoints_to_alarm" {
+  description = "The number of datapoints breaching threshold to alarm"
+  type        = number
+  default     = 3
+}
+
+variable "elb_indexwork_host_count_disabled" {
+  description = "Whether to disable the specific alarm"
+  type        = bool
+  default     = false
+}
+
+variable "elb_indexwork_host_count_evaluation_periods" {
+  description = "The number of periods over which the metric is evaluated"
+  type        = number
+  default     = 4
+}
+
+variable "elb_indexwork_host_count_period" {
+  description = "The number of seconds over which the metric is evaluated"
+  type        = number
+  default     = 900
+}
+
+variable "elb_indexwork_host_count_sns_arns" {
+  description = "The SNS topic arns to notify when the alarm fires"
+  type        = list(string)
+  default     = null
+}
+
+variable "elb_indexwork_host_count_threshold" {
+  description = "Alarms when the metric is below this value"
+  type        = number
+  default     = 0.5
+}
+
 variable "elb_lineagework_host_count_datapoints_to_alarm" {
   description = "The number of datapoints breaching threshold to alarm"
   type        = number
@@ -2232,6 +2268,42 @@ variable "ecs_datawork_mem_sns_arns" {
 }
 
 variable "ecs_datawork_mem_threshold" {
+  description = "Alarms when the metric is above this value"
+  type        = number
+  default     = 70
+}
+
+variable "ecs_indexwork_mem_disabled" {
+  description = "Whether to disable the specific alarm"
+  type        = bool
+  default     = false
+}
+
+variable "ecs_indexwork_mem_dataponts_to_alarm" {
+  description = "The number of datapoints breaching threshold to alarm"
+  type        = number
+  default     = 4
+}
+
+variable "ecs_indexwork_mem_evaluation_periods" {
+  description = "The number of periods over which the metric is evaluated"
+  type        = number
+  default     = 5
+}
+
+variable "ecs_indexwork_mem_period" {
+  description = "The number of seconds over which the metric is evaluated"
+  type        = number
+  default     = 300
+}
+
+variable "ecs_indexwork_mem_sns_arns" {
+  description = "The SNS topic arns to notify when the alarm fires"
+  type        = list(string)
+  default     = null
+}
+
+variable "ecs_indexwork_mem_threshold" {
   description = "Alarms when the metric is above this value"
   type        = number
   default     = 70

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -80,6 +80,7 @@ locals {
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"
   datawork_dns_name                       = "${local.base_dns_alias}-datawork.${var.top_level_dns_name}"
+  indexwork_dns_name                      = "${local.base_dns_alias}-indexwork.${var.top_level_dns_name}"
   lineagework_dns_name                    = "${local.base_dns_alias}-lineagework.${var.top_level_dns_name}"
   metricwork_dns_name                     = "${local.base_dns_alias}-metricwork.${var.top_level_dns_name}"
   internalapi_dns_name                    = "${local.base_dns_alias}-internalapi.${var.top_level_dns_name}"
@@ -137,6 +138,7 @@ locals {
   temporal_image_tag     = coalesce(var.temporal_image_tag, var.image_tag)
   datawatch_image_tag    = coalesce(var.datawatch_image_tag, var.image_tag)
   datawork_image_tag     = coalesce(var.datawork_image_tag, var.image_tag)
+  indexwork_image_tag    = coalesce(var.indexwork_image_tag, var.image_tag)
   lineagework_image_tag  = coalesce(var.lineagework_image_tag, var.image_tag)
   metricwork_image_tag   = coalesce(var.metricwork_image_tag, var.image_tag)
   internalapi_image_tag  = coalesce(var.internalapi_image_tag, var.image_tag)

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -114,6 +114,21 @@ output "datawork_load_balancer_zone_id" {
   value       = module.datawork.zone_id
 }
 
+output "indexwork_dns_name" {
+  description = "DNS name for the indexwork service"
+  value       = local.indexwork_dns_name
+}
+
+output "indexwork_load_balancer_dns_name" {
+  description = "The dns name of the indexwork load balancer"
+  value       = module.indexwork.dns_name
+}
+
+output "indexwork_load_balancer_zone_id" {
+  description = "The Route53 Zone ID of the indexwork load balancer"
+  value       = module.indexwork.zone_id
+}
+
 output "lineagework_dns_name" {
   description = "DNS name for the lineagework service"
   value       = local.lineagework_dns_name

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -39,6 +39,15 @@ variable "enable_bigeye_admin_module" {
 }
 
 #======================================================
+# Short lived rollout flags
+#======================================================
+variable "indexwork_enabled" {
+  description = "Set to true to move the MQ queue for catalog indexing from datawork to indexwork"
+  type        = bool
+  default     = false
+}
+
+#======================================================
 # Access Logs
 #======================================================
 variable "elb_access_logs_enabled" {
@@ -1967,6 +1976,69 @@ variable "datawork_jvm_max_ram_pct" {
 }
 
 variable "datawork_enable_ecs_exec" {
+  description = "Whether to enable ECS exec"
+  type        = bool
+  default     = false
+}
+
+#======================================================
+# Application Variables - Indexwork
+#======================================================
+variable "indexwork_image_tag" {
+  description = "The image tag to use for indexwork, defaults to the global `image_tag` if not specified"
+  type        = string
+  default     = ""
+}
+
+variable "indexwork_desired_count" {
+  description = "The desired number of replicas"
+  type        = number
+  default     = 0
+}
+
+variable "indexwork_cpu" {
+  description = "Amount of CPU to allocate"
+  type        = number
+  default     = 1024
+}
+
+variable "indexwork_memory" {
+  description = "Amount of Memory in MB to allocate"
+  type        = number
+  default     = 4096
+}
+
+variable "indexwork_port" {
+  description = "The port to listen on"
+  type        = number
+  default     = 80
+}
+
+variable "indexwork_additional_environment_vars" {
+  description = "Additional enviromnent variables to give the application"
+  type        = map(string)
+  default     = {}
+}
+
+variable "indexwork_extra_security_group_ids" {
+  description = "Additional security group ids to indexwork"
+  type        = list(string)
+  default     = []
+}
+
+variable "indexwork_lb_extra_security_group_ids" {
+  description = "Additional security group ids to indexwork ALB"
+  type        = list(string)
+  default     = []
+}
+
+variable "indexwork_jvm_max_ram_pct" {
+  description = ""
+  type        = number
+  default     = 80
+}
+
+variable "indexwork_enable_ecs_exec" {
   description = "Whether to enable ECS exec"
   type        = bool
   default     = false


### PR DESCRIPTION
This service will be dedicated to handle the heavy catalog indexing queue to try and isolate the work and get memory and instance overloading under control.  For now we will start with just the dataset_index_op_v2 queue.

Rollout plan:
1. Launch with 0 instances
2. Update internal deployment tooling to handle the new service
3. Turn up instance count which will migrate the jobs to the new service