### PR TITLE
fix: use a set instead of count in redis and RDS security groups 1/2

### DIFF
--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -71,25 +71,26 @@ resource "aws_vpc_security_group_ingress_rule" "client_sg" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "other_sgs" {
-  count             = var.create_security_groups ? length(var.allowed_client_security_group_ids) : 0
+  for_each          = var.create_security_groups ? toset(var.allowed_client_security_group_ids) : []
   security_group_id = aws_security_group.db[0].id
 
   from_port                    = 3306
   to_port                      = 3306
   ip_protocol                  = "TCP"
-  description                  = "Allows MySQL port from ${var.allowed_client_security_group_ids[count.index]}"
-  referenced_security_group_id = var.allowed_client_security_group_ids[count.index]
+  description                  = "Allows MySQL port from ${each.value}"
+  referenced_security_group_id = each.value
 }
 
 resource "aws_vpc_security_group_ingress_rule" "additional_cidrs" {
-  count             = var.create_security_groups ? length(var.additional_ingress_cidrs) : 0
+  #   count             = var.create_security_groups ? length(var.additional_ingress_cidrs) : 0
+  for_each          = var.create_security_groups ? toset(var.additional_ingress_cidrs) : []
   security_group_id = aws_security_group.db[0].id
 
   from_port   = 3306
   to_port     = 3306
   ip_protocol = "TCP"
-  description = "Allows MySQL port from ${var.additional_ingress_cidrs[count.index]}"
-  cidr_ipv4   = var.additional_ingress_cidrs[count.index]
+  description = "Allows MySQL port from ${each.value}"
+  cidr_ipv4   = each.value
 }
 
 resource "aws_security_group" "db_clients" {
@@ -124,25 +125,25 @@ resource "aws_vpc_security_group_ingress_rule" "replica_client_sg" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "replica_other_sgs" {
-  count             = var.create_security_groups && var.create_replica ? length(var.allowed_client_security_group_ids) : 0
+  for_each          = var.create_security_groups && var.create_replica ? toset(var.allowed_client_security_group_ids) : []
   security_group_id = aws_security_group.db_replica[0].id
 
   from_port                    = 3306
   to_port                      = 3306
   ip_protocol                  = "TCP"
-  description                  = "Allows MySQL port from ${var.allowed_client_security_group_ids[count.index]}"
-  referenced_security_group_id = var.allowed_client_security_group_ids[count.index]
+  description                  = "Allows MySQL port from ${each.value}"
+  referenced_security_group_id = each.value
 }
 
 resource "aws_vpc_security_group_ingress_rule" "replica_additional_cidrs" {
-  count             = var.create_security_groups && var.create_replica ? length(var.additional_ingress_cidrs) : 0
+  for_each          = var.create_security_groups && var.create_replica ? toset(var.additional_ingress_cidrs) : []
   security_group_id = aws_security_group.db_replica[0].id
 
   from_port   = 3306
   to_port     = 3306
   ip_protocol = "TCP"
-  description = "Allows MySQL port from ${var.additional_ingress_cidrs[count.index]}"
-  cidr_ipv4   = var.additional_ingress_cidrs[count.index]
+  description = "Allows MySQL port from ${each.value}"
+  cidr_ipv4   = each.value
 }
 
 resource "aws_security_group" "db_replica_clients" {

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -74,23 +74,23 @@ resource "aws_vpc_security_group_ingress_rule" "client_sg" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "other_sgs" {
-  count             = var.create_security_groups ? length(var.allowed_client_security_group_ids) : 0
+  for_each          = var.create_security_groups ? toset(var.allowed_client_security_group_ids) : []
   security_group_id = aws_security_group.this[0].id
 
   from_port                    = 6379
   to_port                      = 6379
   ip_protocol                  = "TCP"
-  description                  = "Allows redis port from ${var.allowed_client_security_group_ids[count.index]}"
-  referenced_security_group_id = var.allowed_client_security_group_ids[count.index]
+  description                  = "Allows redis port from ${each.value}"
+  referenced_security_group_id = each.value
 }
 
 resource "aws_vpc_security_group_ingress_rule" "additional_cidrs" {
-  count             = var.create_security_groups ? length(var.additional_ingress_cidrs) : 0
+  for_each          = var.create_security_groups ? toset(var.additional_ingress_cidrs) : []
   security_group_id = aws_security_group.this[0].id
 
   from_port   = 6379
   to_port     = 6379
   ip_protocol = "TCP"
-  description = "Allows redis port from ${var.additional_ingress_cidrs[count.index]}"
-  cidr_ipv4   = var.additional_ingress_cidrs[count.index]
+  description = "Allows redis port from ${each.value}"
+  cidr_ipv4   = each.value
 }


### PR DESCRIPTION
This is a bug.  Using the count will result in conflicts if the list membership ever change.  The canonical TF way is to use a for_each on a set as this prevents it.

We will need this in a subsequent PR when we add the Indexwork service