### PR TITLE
feat: autoscale indexwork service

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2345,6 +2345,11 @@ module "datawork" {
   secret_arns = local.datawatch_secret_arns
 }
 
+locals {
+  # TODO clean this up when indexwork_enabled featureflag is cleaned up SRE-3855
+  indexwork_autoscaling_enabled = var.indexwork_enabled && var.indexwork_autoscaling_enabled
+}
+
 module "indexwork" {
   depends_on = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key]
   source     = "../simpleservice"
@@ -2380,6 +2385,7 @@ module "indexwork" {
   lb_access_logs_bucket_prefix = format("%s-%s", local.elb_access_logs_prefix, "indexwork")
 
   # Task settings
+  control_desired_count     = local.indexwork_autoscaling_enabled ? false : true
   desired_count             = var.indexwork_desired_count
   cpu                       = var.indexwork_cpu
   memory                    = var.indexwork_memory
@@ -2426,6 +2432,74 @@ module "indexwork" {
   )
 
   secret_arns = local.datawatch_secret_arns
+}
+
+resource "aws_appautoscaling_target" "indexwork" {
+  count              = local.indexwork_autoscaling_enabled ? 1 : 0
+  depends_on         = [module.indexwork]
+  min_capacity       = 0
+  max_capacity       = 100
+  resource_id        = format("service/%s/%s-indexwork", local.name, local.name)
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "indexwork" {
+  count              = local.indexwork_autoscaling_enabled ? 1 : 0
+  depends_on         = [aws_appautoscaling_target.indexwork]
+  name               = format("%s-indexwork-autoscaling", local.name)
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.indexwork[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.indexwork[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.indexwork[0].service_namespace
+  step_scaling_policy_configuration {
+    adjustment_type         = "ExactCapacity"
+    cooldown                = 600
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      scaling_adjustment          = var.indexwork_desired_count
+      metric_interval_upper_bound = var.indexwork_autoscaling_threshold_step1
+    }
+
+    step_adjustment {
+      scaling_adjustment          = var.indexwork_desired_count_step1
+      metric_interval_lower_bound = var.indexwork_autoscaling_threshold_step1
+      metric_interval_upper_bound = var.indexwork_autoscaling_threshold_step2
+    }
+
+    step_adjustment {
+      scaling_adjustment          = var.indexwork_desired_count_step2
+      metric_interval_lower_bound = var.indexwork_autoscaling_threshold_step2
+      metric_interval_upper_bound = var.indexwork_autoscaling_threshold_step3
+    }
+
+    step_adjustment {
+      scaling_adjustment          = var.indexwork_desired_count_step3
+      metric_interval_lower_bound = var.indexwork_autoscaling_threshold_step3
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "indexwork" {
+  count           = local.indexwork_autoscaling_enabled && local.create_rabbitmq ? 1 : 0
+  alarm_name      = format("%s-indexwork autoscaling", local.name)
+  actions_enabled = true
+  alarm_actions   = [aws_appautoscaling_policy.indexwork[0].arn]
+  metric_name     = "MessageCount"
+  namespace       = "AWS/AmazonMQ"
+  statistic       = "Average"
+  dimensions = {
+    Broker      = module.rabbitmq[0].name
+    VirtualHost = "/"
+    Queue       = "dataset_index_op_v2"
+  }
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "missing"
 }
 
 module "lineagework" {

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2044,6 +2044,49 @@ variable "indexwork_enable_ecs_exec" {
   default     = false
 }
 
+variable "indexwork_autoscaling_enabled" {
+  description = "Whether autoscaling is enabled. Note - if you change this variable, it changes the terraform resource that is created. You must run 'terraform state mv' in order to gracefully make this change"
+  type        = bool
+  default     = true
+}
+
+variable "indexwork_autoscaling_threshold_step1" {
+  description = "The first autothreshold metric step"
+  type        = number
+  default     = 1
+}
+
+variable "indexwork_autoscaling_threshold_step2" {
+  description = "The second autothreshold metric step"
+  type        = number
+  default     = 1000
+}
+
+variable "indexwork_autoscaling_threshold_step3" {
+  description = "The third and final autothreshold metric step"
+  type        = number
+  default     = 10000
+}
+
+variable "indexwork_desired_count_step1" {
+  description = "How many tasks to run after reaching the first autoscaling step"
+  type        = number
+  default     = 1
+}
+
+variable "indexwork_desired_count_step2" {
+  description = "How many tasks to run after reaching the second autoscaling step"
+  type        = number
+  default     = 2
+}
+
+variable "indexwork_desired_count_step3" {
+  description = "How many tasks to run after reaching the third and final autoscaling step"
+  type        = number
+  default     = 4
+}
+
+
 #======================================================
 # Application Variables - Lineagework
 #======================================================

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1991,7 +1991,7 @@ variable "indexwork_image_tag" {
 }
 
 variable "indexwork_desired_count" {
-  description = "The desired number of replicas"
+  description = "The desired number of replicas.  If autoscaling is enabled, this is largely ignored and should be left at 0.  See var.indexwork_autoscaling_max_count."
   type        = number
   default     = 0
 }
@@ -2044,48 +2044,18 @@ variable "indexwork_enable_ecs_exec" {
   default     = false
 }
 
+# TODO set to true after FF is cleaned up SRE-3866
 variable "indexwork_autoscaling_enabled" {
-  description = "Whether autoscaling is enabled. Note - if you change this variable, it changes the terraform resource that is created. You must run 'terraform state mv' in order to gracefully make this change"
+  description = "Whether autoscaling is enabled."
   type        = bool
-  default     = true
+  default     = false
 }
 
-variable "indexwork_autoscaling_threshold_step1" {
-  description = "The first autothreshold metric step"
+variable "indexwork_autoscaling_max_count" {
+  description = "When there is work in the queue, the indexwork will scale up to this number of instances."
   type        = number
-  default     = 1
+  default     = 8
 }
-
-variable "indexwork_autoscaling_threshold_step2" {
-  description = "The second autothreshold metric step"
-  type        = number
-  default     = 1000
-}
-
-variable "indexwork_autoscaling_threshold_step3" {
-  description = "The third and final autothreshold metric step"
-  type        = number
-  default     = 10000
-}
-
-variable "indexwork_desired_count_step1" {
-  description = "How many tasks to run after reaching the first autoscaling step"
-  type        = number
-  default     = 1
-}
-
-variable "indexwork_desired_count_step2" {
-  description = "How many tasks to run after reaching the second autoscaling step"
-  type        = number
-  default     = 2
-}
-
-variable "indexwork_desired_count_step3" {
-  description = "How many tasks to run after reaching the third and final autoscaling step"
-  type        = number
-  default     = 4
-}
-
 
 #======================================================
 # Application Variables - Lineagework


### PR DESCRIPTION
This is an MQ based service so lends itself naturally to autoscaling.

Catalog indexing is not a real-time operation so autoscaling down to 0 when the queue is empty is ideal