### PR TITLE
feat!: rollout indexwork service

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,26 @@ It is always recommended to be on the latest
 terraform version and application version.
 
 | terraform-modules Version | Application Version | Comment                                                                                  |
-|---------------------------|-----------|------------------------------------------------------------------------------------------|
-| >= 11.4.0                 | 1.71.0    | migrate queue membership to "include" list that became available in app version `1.71.0` |
-| >= 9.2.0                  | 1.65.0    | mTLS support in datawatch services removed, requires TF settings introduced in `9.2.0`   |
-| 9.2.0                     | >= 1.57.0 | TF adds temporal settings that were released in app version 1.57.0                       |
-| >= 3.12.0                 | 1.48.0    | Application 1.48.0 requires at least terraform-modules version 3.12.0                    |
+|---------------------------|---------------------|------------------------------------------------------------------------------------------|
+| >= 12.0.0                 | 1.73.0              | dedicated indexwork service for catalog indexing operations                              |
+| >= 11.4.0                 | 1.71.0              | migrate queue membership to "include" list that became available in app version `1.71.0` |
+| >= 9.2.0                  | 1.65.0              | mTLS support in datawatch services removed, requires TF settings introduced in `9.2.0`   |
+| 9.2.0                     | >= 1.57.0           | TF adds temporal settings that were released in app version 1.57.0                       |
+| >= 3.12.0                 | 1.48.0              | Application 1.48.0 requires at least terraform-modules version 3.12.0                    |
 
 ## Upgrading
+
+### Upgrading to 12.0.0
+
+The following feature flags will need to be removed from your config if you
+are using them:
+
+- indexwork_enabled
+- indexwork_autoscaling_enabled
+
+### Upgrading to 10.0.0
+
+All variables with papi in the name need to be globally replaced with internalapi.
 
 ### Upgrading to 1.0.0
 

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -41,11 +41,6 @@ variable "enable_bigeye_admin_module" {
 #======================================================
 # Short lived rollout flags
 #======================================================
-variable "indexwork_enabled" {
-  description = "Set to true to move the MQ queue for catalog indexing from datawork to indexwork"
-  type        = bool
-  default     = false
-}
 
 #======================================================
 # Access Logs
@@ -1990,16 +1985,10 @@ variable "indexwork_image_tag" {
   default     = ""
 }
 
-variable "indexwork_desired_count" {
-  description = "The desired number of replicas.  If autoscaling is enabled, this is largely ignored and should be left at 0.  See var.indexwork_autoscaling_max_count."
-  type        = number
-  default     = 0
-}
-
 variable "indexwork_cpu" {
   description = "Amount of CPU to allocate"
   type        = number
-  default     = 1024
+  default     = 2048
 }
 
 variable "indexwork_memory" {
@@ -2040,13 +2029,6 @@ variable "indexwork_jvm_max_ram_pct" {
 
 variable "indexwork_enable_ecs_exec" {
   description = "Whether to enable ECS exec"
-  type        = bool
-  default     = false
-}
-
-# TODO set to true after FF is cleaned up SRE-3866
-variable "indexwork_autoscaling_enabled" {
-  description = "Whether autoscaling is enabled."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
This PRis removing the feature flags to control if indexwork is on or not.  It is just on going forward.

Catalog indexing is a CPU intensive process that is quite bursty in nature.  As such it has been moved to a dedicated service for resource isolation and hardware efficiency.  Note that the service will autoscale down to 0 instances when the queue is empty.  This is normal.

BREAKING CHANGE: The following feature flags will need to be removed from your config if you are using them:

- indexwork_enabled
- indexwork_autoscaling_enabled