### PR TITLE
feat: reduce default indexwork instance count

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2054,7 +2054,7 @@ variable "indexwork_autoscaling_enabled" {
 variable "indexwork_autoscaling_max_count" {
   description = "When there is work in the queue, the indexwork will scale up to this number of instances."
   type        = number
-  default     = 8
+  default     = 2
 }
 
 #======================================================


### PR DESCRIPTION
2 is an efficient number for most self-hoted installs and will be able to service requests in a reasonable time for several thousand tables.