### PR TITLE
fix: update queue membership for MQ based metric runs

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2320,9 +2320,9 @@ module "datawork" {
       DATAWATCH_ADDRESS                  = "http://localhost:${var.datawork_port}"
       WORKERS_ENABLED                    = "true"
       MAX_RAM_PERCENTAGE                 = var.datawork_jvm_max_ram_pct
-      METRIC_RUN_WORKERS                 = "1"
+      METRIC_RUN_WORKERS                 = "0"
       EXCLUDE_QUEUES                     = "trigger-batch-metric-run,source-lineage,metacenter-lineage"
-      MQ_EXCLUDE_QUEUES                  = "dataset_index_op_v2"
+      MQ_EXCLUDE_QUEUES                  = "dataset_index_op_v2,metric_batch"
       HEAP_DUMP_PATH                     = contains(var.efs_volume_enabled_services, "datawork") ? var.efs_mount_point : ""
       RUN_METRICS_WF_EXEC_SIZE           = var.temporal_client_run_metrics_wf_exec_size
       RUN_METRICS_ACT_EXEC_SIZE          = var.temporal_client_run_metrics_act_exec_size
@@ -2557,7 +2557,7 @@ module "lineagework" {
       DATAWATCH_ADDRESS            = "http://localhost:${var.lineagework_port}"
       WORKERS_ENABLED              = "true"
       MAX_RAM_PERCENTAGE           = var.lineagework_jvm_max_ram_pct
-      METRIC_RUN_WORKERS           = "1"
+      METRIC_RUN_WORKERS           = "0"
       INCLUDE_QUEUES               = "source-lineage,metacenter-lineage"
       MQ_WORKERS_ENABLED           = "false"
       HEAP_DUMP_PATH               = contains(var.efs_volume_enabled_services, "lineagework") ? var.efs_mount_point : ""
@@ -2645,7 +2645,7 @@ module "metricwork" {
       MAX_RAM_PERCENTAGE                     = var.metricwork_jvm_max_ram_pct
       METRIC_RUN_WORKERS                     = "1"
       INCLUDE_QUEUES                         = "trigger-batch-metric-run"
-      MQ_WORKERS_ENABLED                     = "false"
+      MQ_INCLUDE_QUEUES                      = "metric_batch"
       HEAP_DUMP_PATH                         = contains(var.efs_volume_enabled_services, "metricwork") ? var.efs_mount_point : ""
       TRIGGER_BATCH_METRIC_RUN_WF_EXEC_SIZE  = var.temporal_client_trigger_batch_metric_run_wf_exec_size
       TRIGGER_BATCH_METRIC_RUN_ACT_EXEC_SIZE = var.temporal_client_trigger_batch_metric_run_act_exec_size


### PR DESCRIPTION
Metric runs should all go to a single service - metricwork.

I don't think this makes any material changes, but is good to keep the house orderly.