### PR TITLE
Indexwork hardware tuning

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2447,8 +2447,8 @@ resource "aws_appautoscaling_policy" "indexwork" {
   service_namespace  = aws_appautoscaling_target.indexwork.service_namespace
   step_scaling_policy_configuration {
     adjustment_type         = "ExactCapacity"
-    cooldown                = 600
-    metric_aggregation_type = "Average"
+    cooldown                = 300
+    metric_aggregation_type = "Minimum"
 
     # Scale to 0 when there is no work on the queue
     step_adjustment {

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1807,7 +1807,7 @@ variable "datawatch_desired_count" {
 variable "datawatch_cpu" {
   description = "Amount of CPU to allocate"
   type        = number
-  default     = 1024
+  default     = 2048
 }
 
 variable "datawatch_memory" {


### PR DESCRIPTION
commit 901c8938113955ee6512dbe429ccd60e2a29e7c9 (HEAD -> david/sre-3860-indexwork-hardware-tuning, origin/david/sre-3860-indexwork-hardware-tuning)
Author: David Nguyen <david@bigeye.com>
Date:   Mon Nov 4 14:44:15 2024 -0800

    feat: increase datawatch default cpu

    This service tends to be hungry and the setting affects UI and
    API performance.  2CPU is a good starting point for most installations

commit 8e0efaf1be646d5274d26cbea6891a144bf2e3be
Author: David Nguyen <david@bigeye.com>
Date:   Mon Nov 4 14:40:48 2024 -0800

    feat: scale indexwork in faster

    Scale out ignores the cooldown so will happen whenever a new
    message shows up on the queue, but we can scale-in faster by having
    a shorter cooldown.

    After some observation we have quite a few periods where there are
    very small numbers of jobs on the queue that trickle in, so scaling
    in faster will be a little more efficient.

    This time is still longer than the instance stop delay so will
    not affect how long we wait for a task to terminate.