### PR TITLE
feat: disable lineagework service by default

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2056,7 +2056,7 @@ variable "lineagework_image_tag" {
 variable "lineagework_desired_count" {
   description = "The desired number of replicas"
   type        = number
-  default     = 1
+  default     = 0
 }
 
 variable "lineagework_cpu" {


### PR DESCRIPTION
This service is only used for installs with the Linege feature enabled.  This is very specific and requires additional hardware, so at this time, the lineagework service should come up disabled (with no instances running) to save on hardware costs