### PR TITLE
feat!: roll out lineage and catalog indexing queue migrations

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -43,24 +43,27 @@ locals {
 
   datawork_mq_exclude_queues = join(",",
     concat(
-      compact([
-        "dataset_index_op_v2",
-        "metric_batch",
-        var.migrate_lineage_mq_queue_enabled ? "lineage" : "",
-        var.migrate_catalog_indexing_mq_queue_enabled ? "catalog_index_v2" : "",
-      ]),
       local.backfillwork_mq_include_queues,
+      local.indexwork_mq_include_queues,
+      local.lineagework_mq_include_queues,
+      local.metricwork_mq_include_queues,
     )
   )
 
-  indexwork_mq_include_queues = join(",", compact([
+  indexwork_mq_include_queues = compact([
     "dataset_index_op_v2",
-    var.migrate_catalog_indexing_mq_queue_enabled ? "catalog_index_v2" : "",
-  ]))
-  lineagework_mq_include_queues = join(",", compact([
-    var.migrate_lineage_mq_queue_enabled ? "lineage" : ""
-  ]))
-  metricwork_mq_include_queues = "metric_batch"
+    "catalog_index_v2",
+  ])
+  indexwork_mq_include_queues_str = join(",", local.indexwork_mq_include_queues)
+
+  lineagework_mq_include_queues = compact([
+    "lineage"
+  ])
+  lineagework_mq_include_queues_str = join(",", local.lineagework_mq_include_queues)
+  metricwork_mq_include_queues = compact([
+    "metric_batch"
+  ])
+  metricwork_mq_include_queues_str = join(",", local.metricwork_mq_include_queues)
 
   # AWS Account
   aws_account_id = data.aws_caller_identity.current.account_id

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2620,7 +2620,7 @@ module "indexwork" {
       WORKERS_ENABLED          = "true"
       MAX_RAM_PERCENTAGE       = var.indexwork_jvm_max_ram_pct
       METRIC_RUN_WORKERS       = "0"
-      MQ_INCLUDE_QUEUES        = local.indexwork_mq_include_queues
+      MQ_INCLUDE_QUEUES        = local.indexwork_mq_include_queues_str
       HEAP_DUMP_PATH           = contains(var.efs_volume_enabled_services, "indexwork") ? var.efs_mount_point : ""
       TEMPORAL_WORKERS_ENABLED = "false"
     },
@@ -2640,7 +2640,6 @@ resource "aws_appautoscaling_target" "indexwork" {
 }
 
 resource "aws_appautoscaling_policy" "indexwork" {
-  count              = var.migrate_catalog_indexing_mq_queue_enabled ? 1 : 0
   depends_on         = [aws_appautoscaling_target.indexwork]
   name               = format("%s-indexwork-catalog-autoscaling", local.name)
   policy_type        = "StepScaling"
@@ -2669,10 +2668,9 @@ resource "aws_appautoscaling_policy" "indexwork" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "indexwork" {
-  count               = var.migrate_catalog_indexing_mq_queue_enabled ? 1 : 0
   alarm_name          = "${local.name}-indexwork autoscaling"
   actions_enabled     = true
-  alarm_actions       = [aws_appautoscaling_policy.indexwork[0].arn]
+  alarm_actions       = [aws_appautoscaling_policy.indexwork.arn]
   evaluation_periods  = 1
   datapoints_to_alarm = 1
   threshold           = 0
@@ -2797,8 +2795,8 @@ module "lineagework" {
       MAX_RAM_PERCENTAGE           = var.lineagework_jvm_max_ram_pct
       METRIC_RUN_WORKERS           = "0"
       INCLUDE_QUEUES               = "source-lineage,metacenter-lineage"
-      MQ_WORKERS_ENABLED           = var.migrate_lineage_mq_queue_enabled ? "true" : "false"
-      MQ_INCLUDE_QUEUES            = local.lineagework_mq_include_queues
+      MQ_WORKERS_ENABLED           = "true"
+      MQ_INCLUDE_QUEUES            = local.lineagework_mq_include_queues_str
       HEAP_DUMP_PATH               = contains(var.efs_volume_enabled_services, "lineagework") ? var.efs_mount_point : ""
       SOURCE_LINEAGE_WF_EXEC_SIZE  = var.temporal_client_source_lineage_wf_exec_size
       SOURCE_LINEAGE_ACT_EXEC_SIZE = var.temporal_client_source_lineage_act_exec_size
@@ -2884,7 +2882,7 @@ module "metricwork" {
       MAX_RAM_PERCENTAGE                     = var.metricwork_jvm_max_ram_pct
       METRIC_RUN_WORKERS                     = "1"
       INCLUDE_QUEUES                         = "trigger-batch-metric-run"
-      MQ_INCLUDE_QUEUES                      = local.metricwork_mq_include_queues
+      MQ_INCLUDE_QUEUES                      = local.metricwork_mq_include_queues_str
       HEAP_DUMP_PATH                         = contains(var.efs_volume_enabled_services, "metricwork") ? var.efs_mount_point : ""
       TRIGGER_BATCH_METRIC_RUN_WF_EXEC_SIZE  = var.temporal_client_trigger_batch_metric_run_wf_exec_size
       TRIGGER_BATCH_METRIC_RUN_ACT_EXEC_SIZE = var.temporal_client_trigger_batch_metric_run_act_exec_size

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -41,17 +41,6 @@ variable "enable_bigeye_admin_module" {
 #======================================================
 # Short lived rollout flags
 #======================================================
-variable "migrate_lineage_mq_queue_enabled" {
-  description = "When true, move the lineage MQ queue to the lineagework service.  This is experimental, not recommended for production."
-  type        = bool
-  default     = false
-}
-
-variable "migrate_catalog_indexing_mq_queue_enabled" {
-  description = "When true, move the catalog_index_v2 MQ queue to the indexwork service.  This is experimental, not recommended for production."
-  type        = bool
-  default     = false
-}
 
 #======================================================
 # Access Logs


### PR DESCRIPTION
This change has been vetted and is ready for 100% rollout so the feature flags are being removed.

The following queues will migrate off of datawork:
- lineage MQ queue will be serviced from lineagework
- catalog_index_v2 MQ queue will be serviced from indexwork

BREAKING CHANGE:

The following bigeye module variables have been removed:
- migrate_lineage_mq_queue_enabled
- migrate_catalog_indexing_mq_queue_enabled

Remove these from your configuration before upgrading to this version of the Bigeye terraform module.  If these have not been set before, no action is required.