### PR TITLE
fix!: disable autoscaling for indexwork service

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ the Bigeye stack into an AWS Environment.
 
 [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli#install-terraform)
 
-- at least version 1.0.  We find that
-`tfenv` ([link](https://github.com/tfutils/tfenv)) is a useful way to install
-& manage Terraform versions
+- at least version 1.0. We find that
+  `tfenv` ([link](https://github.com/tfutils/tfenv)) is a useful way to install
+  & manage Terraform versions
 
 ### AWS
 
@@ -52,7 +52,7 @@ terraform version and application version.
 ### Upgrading to 14.0.0
 
 The following variable will need to be removed from your config if you
-are using it. 
+are using it.
 
 - indexwork_autoscaling_max_count
 
@@ -81,7 +81,7 @@ All variables with papi in the name need to be globally replaced with internalap
 
 ### Upgrading to 1.0.0
 
->IMPORTANT - There are a few breaking changes in this release.
+> IMPORTANT - There are a few breaking changes in this release.
 
 Please refer to the [changelog](./CHANGELOG.md#100-2023-12-22)
 for more instructions.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ terraform version and application version.
 
 ## Upgrading
 
+### Upgrading to 14.0.0
+
+The following variable will need to be removed from your config if you
+are using it. 
+
+- indexwork_autoscaling_max_count
+
+It has been replaced with `var.indexwork_desired_count` to control the
+instance count for the indexwork service.
+
 ### Upgrading to 13.0.0
 
 The following feature flags will need to be removed from your config if you

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2055,6 +2055,12 @@ variable "indexwork_image_tag" {
   default     = ""
 }
 
+variable "indexwork_desired_count" {
+  description = "The desired number of replicas"
+  type        = number
+  default     = 2
+}
+
 variable "indexwork_cpu" {
   description = "Amount of CPU to allocate"
   type        = number
@@ -2101,12 +2107,6 @@ variable "indexwork_enable_ecs_exec" {
   description = "Whether to enable ECS exec"
   type        = bool
   default     = false
-}
-
-variable "indexwork_autoscaling_max_count" {
-  description = "When there is work in the queue, the indexwork will scale up to this number of instances."
-  type        = number
-  default     = 2
 }
 
 #======================================================


### PR DESCRIPTION
Some jobs are being terminated inflight during scale-in for this service.  Disabling autoscaling for this service is the safest route forward until this is resolved.