### PR TITLE
feat: make indexwork autoscaling configurable via variable

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2581,7 +2581,7 @@ module "indexwork" {
   lb_access_logs_bucket_prefix = format("%s-%s", local.elb_access_logs_prefix, "indexwork")
 
   # Task settings
-  control_desired_count     = false
+  control_desired_count     = var.indexwork_autoscaling_enabled ? false : true
   desired_count             = var.indexwork_desired_count
   cpu                       = var.indexwork_cpu
   memory                    = var.indexwork_memory

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2055,6 +2055,12 @@ variable "indexwork_image_tag" {
   default     = ""
 }
 
+variable "indexwork_autoscaling_enabled" {
+  description = "Whether indexwork autoscaling is enabled. Note - if you change this variable, it changes the terraform resource that is created. You must run 'terraform state mv' in order to gracefully make this change"
+  type        = bool
+  default     = true
+}
+
 variable "indexwork_desired_count" {
   description = "The desired number of replicas"
   type        = number


### PR DESCRIPTION
This change adds a variable that configures indexwork autoscaling feature.

Backward compatible: yes