### PR TITLE
allow alb reqest count per target autoscaling for internalapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ terraform version and application version.
 
 ## Upgrading
 
+### Upgrading to 15.0.0
+
+The following vars have been removed:
+
+- var.monocle_autoscaling_enabled
+- var.monocle_max_count
+- var.monocle_autoscaling_request_count_target
+- var.indexwork_autoscaling_enabled
+- var.internalapi_autoscaling_cpu_enabled
+- var.internalapi_autoscaling_cpu_target
+
+Instead, use:
+
+- var.internalapi_autoscaling_config
+- var.monocle_autoscaling_config
+
 ### Upgrading to 14.0.0
 
 The following variable will need to be removed from your config if you


### PR DESCRIPTION
commit fd178cc7103bbfb08e60574e249b39a6b672cebf (HEAD -> david/sre-3975-increase-the-base-instance-count-for-internalapi-to-more, origin/david/sre-3975-increase-the-base-instance-count-for-internalapi-to-more)
Author: David Nguyen <david@bigeye.com>
Date:   Wed Dec 4 15:49:38 2024 -0800

    feat!: normalize target autoscaling variable names

    monocle is also a target scaling service.  Make the variables look
    the same as internalapi.

    BREAKING CHANGE:

    The following vars have been removed:
    - var.monocle_autoscaling_enabled
    - var.monocle_max_count
    - var.monocle_autoscaling_request_count_target
    - var.indexwork_autoscaling_enabled

    The following vars have been added:
    - var.monocle_autoscaling_min_capacity
    - var.monocle_autoscaling_max_capacity
    - var.monocle_autoscaling_type
    - var.monocle_autoscaling_target_utilization

commit 48a9d30e8c3121451e9189c2cad9a370f096717c
Author: David Nguyen <david@bigeye.com>
Date:   Wed Dec 4 14:50:08 2024 -0800

    feat!: allow alb reqest count per target autoscaling for internalapi

    Allow control over the autoscaling algorithm as request count per target
    is more sensitive, but requires obersvation and babysitting.  If CPU
    scaling is leading to OOM or other overloading due to bursts, switch to
    request count per target or increase the min capacity.

    BREAKING CHANGE:

    The following vars have been removed:
    - var.internalapi_autoscaling_cpu_enabled
    - var.internalapi_autoscaling_cpu_target

    The following vars have been added:
    - var.internalapi_autoscaling_type
    - var.internalapi_autoscaling_min_capacity
    - var.internalapi_autoscaling_max_capacity
    - var.internalapi_autoscaling_target_utilization
