### PR TITLE
fix!: remove autoscaling from backfillwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ terraform version and application version.
 
 ## Upgrading
 
+### Upgrading to 16.0.0
+
+The following var has been removed:
+
+- backfillwork_autoscaling_max_count
+
 ### Upgrading to 15.0.0
 
 The following vars have been removed:

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1929,6 +1929,12 @@ variable "backfillwork_image_tag" {
   default     = ""
 }
 
+variable "backfillwork_desired_count" {
+  description = "The desired number of replicas"
+  type        = number
+  default     = 1
+}
+
 variable "backfillwork_cpu" {
   description = "Amount of CPU to allocate"
   type        = number
@@ -1975,12 +1981,6 @@ variable "backfillwork_enable_ecs_exec" {
   description = "Whether to enable ECS exec"
   type        = bool
   default     = false
-}
-
-variable "backfillwork_autoscaling_max_count" {
-  description = "When there is work in the queue, the backfillwork will scale up to this number of instances."
-  type        = number
-  default     = 2
 }
 
 


### PR DESCRIPTION
During scale-in some backfill tasks can be terminated early which results in work loss.  Hard pinning the instance count for now avoids this.

BREAKING CHANGE:
- var.backfillwork_autoscaling_max_count has been removed