### PR TITLE
feat: set lineagework instance count to 1

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2122,7 +2122,7 @@ variable "lineagework_image_tag" {
 variable "lineagework_desired_count" {
   description = "The desired number of replicas"
   type        = number
-  default     = 0
+  default     = 1
 }
 
 variable "lineagework_cpu" {


### PR DESCRIPTION
This service now also needs to run for self-hosted installs, set the default instance count to 1.

Closes SRE-4025