### PR TITLE
feat: allow setting issue-root-cause temporal client settings

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2371,6 +2371,8 @@ module "datawork" {
       DELETE_SOURCE_ACT_EXEC_SIZE        = var.temporal_client_delete_source_act_exec_size
       GET_SAMPLES_WF_EXEC_SIZE           = var.temporal_client_get_samples_wf_exec_size
       GET_SAMPLES_ACT_EXEC_SIZE          = var.temporal_client_get_samples_act_exec_size
+      ISSUE_ROOT_CAUSE_WF_EXEC_SIZE      = var.temporal_client_issue_root_cause_wf_exec_size
+      ISSUE_ROOT_CAUSE_ACT_EXEC_SIZE     = var.temporal_client_issue_root_cause_act_exec_size
       RECONCILIATION_WF_EXEC_SIZE        = var.temporal_client_reconciliation_wf_exec_size
       RECONCILIATION_ACT_EXEC_SIZE       = var.temporal_client_reconciliation_act_exec_size
       REFRESH_SCORECARDS_WF_EXEC_SIZE    = var.temporal_client_refresh_scorecard_wf_exec_size

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1411,6 +1411,19 @@ variable "temporal_client_indexing_act_exec_size" {
   default     = 200
 }
 
+variable "temporal_client_issue_root_cause_wf_exec_size" {
+  description = "Controls issue-root-cause workflow execution thread count"
+  type        = number
+  default     = 5
+}
+
+variable "temporal_client_issue_root_cause_act_exec_size" {
+  description = "Controls issue-root-cause activity execution thread count"
+  type        = number
+  default     = 4
+}
+
+
 variable "temporal_client_reconciliation_wf_exec_size" {
   description = "Controls reconciliation workflow execution thread count.  This is used for reconciling metric run schedules."
   type        = number


### PR DESCRIPTION
Allow controlling parallelism of this queue.  The max activity account looks strange (4), but this matches what is in the code.

Closes SRE-4020