### PR TITLE
feat: allow control of temporal parallelism remaining queues

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2389,6 +2389,10 @@ module "datawork" {
       EXCLUDE_QUEUES                     = local.datawork_temporal_exclude_queues_str
       MQ_EXCLUDE_QUEUES                  = local.datawork_mq_exclude_queues
       HEAP_DUMP_PATH                     = contains(var.efs_volume_enabled_services, "datawork") ? var.efs_mount_point : ""
+      AGENT_HEARTBEAT_WF_EXEC_SIZE       = var.temporal_client_agent_heartbeat_wf_exec_size
+      AGENT_HEARTBEAT_ACT_EXEC_SIZE      = var.temporal_client_agent_heartbeat_act_exec_size
+      COLLECT_LINEAGE_WF_EXEC_SIZE       = var.temporal_client_collect_lineage_wf_exec_size
+      COLLECT_LINEAGE_ACT_EXEC_SIZE      = var.temporal_client_collect_lineage_act_exec_size
       RUN_METRICS_WF_EXEC_SIZE           = var.temporal_client_run_metrics_wf_exec_size
       RUN_METRICS_ACT_EXEC_SIZE          = var.temporal_client_run_metrics_act_exec_size
       DELETE_SOURCE_WF_EXEC_SIZE         = var.temporal_client_delete_source_wf_exec_size

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1363,6 +1363,30 @@ variable "temporal_system_visibility_persistence_max_write_qps" {
 #======================================================
 # Application Variables - Temporal Clients (job executor)
 #======================================================
+variable "temporal_client_agent_heartbeat_wf_exec_size" {
+  description = "Controls agent-heartbeat workflow execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_agent_heartbeat_act_exec_size" {
+  description = "Controls agent-heartbeat activity execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_collect_lineage_wf_exec_size" {
+  description = "Controls collect-lineage workflow execution thread count"
+  type        = number
+  default     = 200
+}
+
+variable "temporal_client_collect_lineage_act_exec_size" {
+  description = "Controls collect-lineage activity execution thread count"
+  type        = number
+  default     = 200
+}
+
 variable "temporal_client_run_metrics_wf_exec_size" {
   description = "Controls run-metrics.v1 workflow execution thread count"
   type        = number


### PR DESCRIPTION
These two queues are the last ones.  We will want to be able to restrict them as the default is 200 (200 threads!) and this causes some thrashing on datawork.