### PR TITLE
feat: enable auto minor version upgrade for rabbitmq

### DIFF
--- a/modules/rabbitmq/main.tf
+++ b/modules/rabbitmq/main.tf
@@ -9,8 +9,11 @@ terraform {
 }
 
 resource "aws_mq_broker" "queue" {
-  broker_name                = var.name
-  auto_minor_version_upgrade = false
+  broker_name = var.name
+  # If someone has changed from the original 3.11.20, enable auto minor version upgrade as that is
+  # what AWS requires starting with 3.13 anyways.
+  auto_minor_version_upgrade = var.engine_version == "3.11.20" ? false : true
+  apply_immediately          = true
   deployment_mode            = var.deployment_mode
   engine_type                = "RabbitMQ"
   engine_version             = var.engine_version


### PR DESCRIPTION
Starting with 3.13, AWS requires auto minor version upgrade to be enabled.  This also has to be set _before_ trying to upgrade to 3.13.  So it is just best to set it to true now.

If someone has not touched the default already, leave it set to false.  It will get turned on when they upgrade to 3.12.x anyways and that is required before they upgrade to 3.13 as it is not possible to upgrade from 3.11.x -> 3.13 directly.

![image](https://github.com/user-attachments/assets/ebd80b10-53a2-46c6-920c-259f0562bdc3)

https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-version-management.html