### PR TITLE
fix!: increase minimum hashicorp/aws version to 5.68.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ terraform version and application version.
 
 ## Upgrading
 
+### Upgrading to 17.0.0
+
+The minimum version of the `hashicorp/aws` module has been increased to
+5.68.0.  If your install has the version pinned to something lower,
+increase the version to at least 5.68.0 and run `terraform init -upgrade`.
+
 ### Upgrading to 16.0.0
 
 The following var has been removed:

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.50.0, < 6.0.0"
+      version = ">= 5.68.0, < 6.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
There is a bug with the aws_mq_broker provider that does not handle auto version upgrades properly.  It is resolved as of 5.68.0

See: https://github.com/hashicorp/terraform-provider-aws/issues/38930

This is in preparation for AWS removing support for all versions of rabbit MQ < 3.13 and at version 3.13, they will hard control the patch revisions.

It is recommended to set var.rabbitmq_engine_version to "3.13". 3.13 will become the default for this module after AWS removes support for 3.12.x sometime in the first half of 2025 (currently scheduled for March)

BREAKING CHANGE:

If your installhas the "hashicorp/aws" provider version pinned to something lower than 5.68.0, increase the version to at least 5.68.0 and run `terraform init -upgrade`.