### PR TITLE
feat: enable datawatch_request_body_logging_enabled everywhere

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2210,7 +2210,7 @@ locals {
     FF_QUEUE_BACKFILL_ENABLED       = "true"
     FF_SEND_ANALYTICS_ENABLED       = var.datawatch_feature_analytics_send_enabled
     REQUEST_AUTH_LOGGING_ENABLED    = var.datawatch_request_auth_logging_enabled
-    REQUEST_BODY_LOGGING_ENABLED    = var.datawatch_request_body_logging_enabled
+    REQUEST_BODY_LOGGING_ENABLED    = true
     CLASS_LOADING_LOGGING_ENABLED   = var.datawatch_class_loading_logging_enabled
     MAX_REQUEST_SIZE                = var.datawatch_max_request_size
 

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1951,9 +1951,9 @@ variable "datawatch_feature_jvm_memory_leak_fix" {
 }
 
 variable "datawatch_request_body_logging_enabled" {
-  description = "Whether request body logs are enabled"
+  description = "DEPRECATED: This flag will no longer do anything.  It will be removed in a future release"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "datawatch_request_auth_logging_enabled" {


### PR DESCRIPTION
This flag just controls weather a trace id is logged in the response log from the backend server.  It will be set on (flag control removed) in Bigeye app version 2.2.0 anyways, so we are enabling this across the board in the terraform ahead of the code being released.

This variable will be removed in a future release.