### PR TITLE
fix: update default temporal client parallelism settings

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1366,205 +1366,205 @@ variable "temporal_system_visibility_persistence_max_write_qps" {
 variable "temporal_client_agent_heartbeat_wf_exec_size" {
   description = "Controls agent-heartbeat workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 10
 }
 
 variable "temporal_client_agent_heartbeat_act_exec_size" {
   description = "Controls agent-heartbeat activity execution thread count"
   type        = number
-  default     = 200
+  default     = 10
 }
 
 variable "temporal_client_collect_lineage_wf_exec_size" {
   description = "Controls collect-lineage workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_collect_lineage_act_exec_size" {
   description = "Controls collect-lineage activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_run_metrics_wf_exec_size" {
   description = "Controls run-metrics.v1 workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 8
 }
 
 variable "temporal_client_run_metrics_act_exec_size" {
   description = "Controls run-metrics.v1 activity execution thread count"
   type        = number
-  default     = 200
+  default     = 8
 }
 
 variable "temporal_client_delete_source_wf_exec_size" {
   description = "Controls delete-source.v1 workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_delete_source_act_exec_size" {
   description = "Controls delete-source.v1 activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_external_ticket_wf_exec_size" {
   description = "Controls external-ticket workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_external_ticket_act_exec_size" {
   description = "Controls external-ticket activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_get_samples_wf_exec_size" {
   description = "Controls get-samples.v1 workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_get_samples_act_exec_size" {
   description = "Controls get-samples.v1 activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_indexing_wf_exec_size" {
   description = "Controls indexing.v1 workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_indexing_act_exec_size" {
   description = "Controls indexing.v1 activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_issue_ai_overview_wf_exec_size" {
   description = "Controls issue-ai-overview workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_issue_ai_overview_act_exec_size" {
   description = "Controls issue-ai-overview activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_issue_notify_wf_exec_size" {
   description = "Controls issue-notify workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_issue_notify_act_exec_size" {
   description = "Controls issue-notify activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_issue_root_cause_wf_exec_size" {
   description = "Controls issue-root-cause workflow execution thread count"
   type        = number
-  default     = 5
+  default     = 2
 }
 
 variable "temporal_client_issue_root_cause_act_exec_size" {
   description = "Controls issue-root-cause activity execution thread count"
   type        = number
-  default     = 4
+  default     = 2
 }
 
 variable "temporal_client_issue_update_wf_exec_size" {
   description = "Controls issue-update workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_issue_update_act_exec_size" {
   description = "Controls issue-update activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_reconciliation_wf_exec_size" {
   description = "Controls reconciliation workflow execution thread count.  This is used for reconciling metric run schedules."
   type        = number
-  default     = 5
+  default     = 2
 }
 
 variable "temporal_client_reconciliation_act_exec_size" {
   description = "Controls reconciliation activity execution thread count.  This is used for reconciling metric run schedules."
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_trigger_batch_metric_run_wf_exec_size" {
   description = "Controls trigger-batch-metric-run workflow execution thread count"
   type        = number
-  default     = 5
+  default     = 2
 }
 
 variable "temporal_client_trigger_batch_metric_run_act_exec_size" {
   description = "Controls trigger-batch-metric-run activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_source_lineage_wf_exec_size" {
   description = "Controls source-lineage workflow execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_source_lineage_act_exec_size" {
   description = "Controls source-lineage activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_mc_lineage_wf_exec_size" {
   description = "Controls metacenter-lineage workflow execution thread count"
   type        = number
-  default     = 5
+  default     = 2
 }
 
 variable "temporal_client_mc_lineage_act_exec_size" {
   description = "Controls metacenter-lineage activity execution thread count"
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_refresh_scorecard_wf_exec_size" {
   description = "Controls refresh-scorecards workflow execution thread count.  This is used for refreshing data used in scorecards."
   type        = number
-  default     = 5
+  default     = 2
 }
 
 variable "temporal_client_refresh_scorecard_act_exec_size" {
   description = "Controls refresh-scorecards activity execution thread count.  This is used for refreshing data used in scorecards."
   type        = number
-  default     = 200
+  default     = 2
 }
 
 variable "temporal_client_monocle_invalidation_wf_exec_size" {
   description = "Controls monocle-invalidation workflow execution thread count.  This is used for invalidating Monocle ML models for serving autothresholds."
   type        = number
-  default     = 5
+  default     = 2
 }
 
 variable "temporal_client_monocle_invalidation_act_exec_size" {
   description = "Controls monocle-invalidation activity execution thread count.  This is used for invalidating Monocle ML models for serving autothresholds."
   type        = number
-  default     = 200
+  default     = 2
 }
 
 #======================================================


### PR DESCRIPTION
The existing defaults are far too large.  These settings control the number of threads so hundreds of extra threads were being created which is not efficient.

The remaining settings that are not set to 2 will likely be revisited again sometime in the future.