### PR TITLE
fix: increase parallism for trigger-batch-metric-run activity queue

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1516,7 +1516,7 @@ variable "temporal_client_trigger_batch_metric_run_wf_exec_size" {
 variable "temporal_client_trigger_batch_metric_run_act_exec_size" {
   description = "Controls trigger-batch-metric-run activity execution thread count"
   type        = number
-  default     = 2
+  default     = 5
 }
 
 variable "temporal_client_source_lineage_wf_exec_size" {


### PR DESCRIPTION
2 can end up blocked if there are long queries, especially if data source is queuing queries due to stress