### PR TITLE
feat: add option to use Cloudfront in front of the app

### DIFF
--- a/modules/bigeye/cloudfront.tf
+++ b/modules/bigeye/cloudfront.tf
@@ -1,0 +1,51 @@
+module "cloudfront" {
+  source = "terraform-aws-modules/cloudfront/aws"
+  count  = var.cloudfront_enabled ? 1 : 0
+
+  aliases             = [local.vanity_dns_name]
+  comment             = local.name
+  enabled             = true
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_All"
+  http_version        = "http2and3"
+  wait_for_deployment = false
+  logging_config = {
+    bucket = var.cloudfront_logging_bucket
+    prefix = "bigeye.com"
+  }
+
+  origin = {
+    bigeye = {
+      domain_name         = module.haproxy.dns_name
+      connection_attempts = 3
+      connection_timeout  = 10
+      custom_origin_config = {
+        http_port                = 80
+        https_port               = 443
+        origin_keepalive_timeout = 5
+        origin_protocol_policy   = "https-only"
+        origin_read_timeout      = 30
+        origin_ssl_protocols     = ["TLSv1.2"]
+      }
+    }
+  }
+
+  default_cache_behavior = {
+    target_origin_id           = "bigeye"
+    viewer_protocol_policy     = "redirect-to-https"
+    compress                   = var.cloudfront_compression_enabled
+    use_forwarded_values       = false
+    cache_policy_name          = "UseOriginCacheControlHeaders"
+    origin_request_policy_name = "Managed-AllViewer"
+
+    allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods  = ["GET", "HEAD", "OPTIONS"]
+  }
+
+  viewer_certificate = {
+    cloudfront_default_certificate = false
+    acm_certificate_arn            = var.cloudfront_acm_certificate_arn
+    minimum_protocol_version       = "TLSv1.2_2021"
+    ssl_support_method             = "sni-only"
+  }
+}

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -427,8 +427,8 @@ resource "aws_route53_record" "apex" {
   name    = local.vanity_dns_name
   type    = "A"
   alias {
-    name                   = module.haproxy.dns_name
-    zone_id                = module.haproxy.zone_id
+    name                   = var.cloudfront_enabled ? module.cloudfront[0].cloudfront_distribution_domain_name : module.haproxy.dns_name
+    zone_id                = var.cloudfront_enabled ? module.cloudfront[0].cloudfront_distribution_hosted_zone_id : module.haproxy.zone_id
     evaluate_target_health = false
   }
 }

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2552,3 +2552,30 @@ variable "lineageplus_solr_instance_type" {
   type        = string
   default     = "t3.medium"
 }
+
+#======================================================
+# Cloudfront Variables
+#======================================================
+variable "cloudfront_enabled" {
+  description = "A var.cloudfront_logging_bucket and var.cloudfront_acm_certificate_arn also need to be set in addition to setting this var to true to enable Cloudfront in front of the Bigeye app stack."
+  type        = bool
+  default     = false
+}
+
+variable "cloudfront_logging_bucket" {
+  description = "A logging S3 bucket is required for Cloudfront distributions"
+  type        = string
+  default     = ""
+}
+
+variable "cloudfront_acm_certificate_arn" {
+  description = "An ACM cert is required for Cloudfront distributions"
+  type        = string
+  default     = ""
+}
+
+variable "cloudfront_compression_enabled" {
+  description = ""
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Using a CDN is a standard technique to improve UI performance for requests from latency distant regions.

The caller will pass in both the S3 logging bucket and ACM cert to use with Cloudfront as they are likely to already exist for enterprise installs.