### PR TITLE
feat: improve Cloudfront caching strategy

### DIFF
--- a/modules/bigeye/cloudfront.tf
+++ b/modules/bigeye/cloudfront.tf
@@ -1,3 +1,32 @@
+locals {
+  static_object_path_patterns = [
+    "/*.js",
+    "/*.jpg",
+    "/*.jpeg",
+    "/*.gif",
+    "/*.css",
+    "/*.png",
+    "/*.svg",
+    "/*.webp",
+    "/*.woff2",
+  ]
+  cloudfront_ordered_cache_behavior_defaults = {
+    target_origin_id           = "bigeye"
+    cache_policy_name          = "Managed-CachingOptimized"
+    origin_request_policy_name = "Managed-AllViewer"
+    viewer_protocol_policy     = "redirect-to-https"
+    compress                   = true
+    use_forwarded_values       = false
+    allowed_methods            = ["GET", "HEAD"]
+    cached_methods             = ["GET", "HEAD"]
+  }
+  cloudfront_ordered_cache_behavior = [
+    for path_pattern in local.static_object_path_patterns : merge(
+      { path_pattern = path_pattern }, local.cloudfront_ordered_cache_behavior_defaults
+    )
+  ]
+}
+
 module "cloudfront" {
   source = "terraform-aws-modules/cloudfront/aws"
   count  = var.cloudfront_enabled ? 1 : 0
@@ -29,6 +58,8 @@ module "cloudfront" {
       }
     }
   }
+
+  ordered_cache_behavior = local.cloudfront_ordered_cache_behavior
 
   default_cache_behavior = {
     target_origin_id           = "bigeye"


### PR DESCRIPTION
It is common practice to skip inspecting headers and query params for caching of static objects as it keeps the cache as speedy as possible.  This PR is doing that by assuming based on filename which objects are static and can bypass cache control.

Without this there are far more cache misses than expected.