### PR TITLE
fix: update dns to only route static assets to cloudfront

### DIFF
--- a/modules/bigeye/cloudfront.tf
+++ b/modules/bigeye/cloudfront.tf
@@ -37,7 +37,7 @@ module "cloudfront" {
   is_ipv6_enabled     = true
   price_class         = "PriceClass_All"
   http_version        = "http2and3"
-  wait_for_deployment = false
+  wait_for_deployment = true
   logging_config = {
     bucket = var.cloudfront_logging_bucket
     prefix = "bigeye.com"
@@ -53,7 +53,7 @@ module "cloudfront" {
         https_port               = 443
         origin_keepalive_timeout = 5
         origin_protocol_policy   = "https-only"
-        origin_read_timeout      = 30
+        origin_read_timeout      = var.cloudfront_origin_read_timeout
         origin_ssl_protocols     = ["TLSv1.2"]
       }
     }

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -125,6 +125,7 @@ locals {
   # DNS
   base_dns_alias                          = coalesce(var.vanity_alias, local.name)
   vanity_dns_name                         = var.use_top_level_dns_apex_as_vanity ? var.top_level_dns_name : "${local.base_dns_alias}.${var.top_level_dns_name}"
+  static_asset_dns_name                   = var.use_top_level_dns_apex_as_vanity ? "static.${var.top_level_dns_name}" : "${local.base_dns_alias}-static.${var.top_level_dns_name}"
   datawatch_dns_name                      = "${local.base_dns_alias}-datawatch.${var.top_level_dns_name}"
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -143,7 +143,11 @@ locals {
   toretto_dns_name                        = "${local.base_dns_alias}-toretto.${var.top_level_dns_name}"
   scheduler_dns_name                      = "${local.base_dns_alias}-scheduler.${var.top_level_dns_name}"
   web_dns_name                            = "${local.base_dns_alias}-web.${var.top_level_dns_name}"
-  lineageplus_solr_dns_name               = "${local.base_dns_alias}-lineageplus-solr.${var.top_level_dns_name}"
+  web_static_asset_root = (
+    var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?
+    module.cloudfront[0].cloudfront_distribution_domain_name : module.haproxy.dns_name
+  )
+  lineageplus_solr_dns_name = "${local.base_dns_alias}-lineageplus-solr.${var.top_level_dns_name}"
 
   # RDS DNS - if create_dns_records is disabled, using the RDS-provided DNS name is a more reliable way of getting up and running
   use_rds_vanity_names     = var.create_dns_records ? true : false

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -427,8 +427,26 @@ resource "aws_route53_record" "apex" {
   name    = local.vanity_dns_name
   type    = "A"
   alias {
-    name                   = var.cloudfront_enabled ? module.cloudfront[0].cloudfront_distribution_domain_name : module.haproxy.dns_name
-    zone_id                = var.cloudfront_enabled ? module.cloudfront[0].cloudfront_distribution_hosted_zone_id : module.haproxy.zone_id
+    name                   = module.haproxy.dns_name
+    zone_id                = module.haproxy.zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "static" {
+  count   = var.create_dns_records ? 1 : 0
+  zone_id = data.aws_route53_zone.this[0].zone_id
+  name    = local.static_asset_dns_name
+  type    = "A"
+  alias {
+    name = (
+      var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?
+      module.cloudfront[0].cloudfront_distribution_domain_name : module.haproxy.dns_name
+    )
+    zone_id = (
+      var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?
+      module.cloudfront[0].cloudfront_distribution_hosted_zone_id : module.haproxy.zone_id
+    )
     evaluate_target_health = false
   }
 }

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -439,10 +439,7 @@ resource "aws_route53_record" "static" {
   name    = local.static_asset_dns_name
   type    = "A"
   alias {
-    name = (
-      var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?
-      module.cloudfront[0].cloudfront_distribution_domain_name : module.haproxy.dns_name
-    )
+    name = local.web_static_asset_root
     zone_id = (
       var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?
       module.cloudfront[0].cloudfront_distribution_hosted_zone_id : module.haproxy.zone_id
@@ -1164,6 +1161,7 @@ module "web" {
       INSTANCE          = var.instance
       DOCKER_ENV        = var.environment
       APP_ENVIRONMENT   = var.environment
+      STATIC_ASSET_ROOT = local.web_static_asset_root
       NODE_ENV          = "production"
       PORT              = var.web_port
       DROPWIZARD_HOST   = "https://${local.datawatch_dns_name}"

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2585,7 +2585,23 @@ variable "lineageplus_solr_desired_count" {
 # Cloudfront Variables
 #======================================================
 variable "cloudfront_enabled" {
-  description = "A var.cloudfront_logging_bucket and var.cloudfront_acm_certificate_arn also need to be set in addition to setting this var to true to enable Cloudfront in front of the Bigeye app stack."
+  description = <<EOT
+This controls whether a Cloudfront distribution is created.  This should be set to true before
+setting var.cloudfront_route_static_asset_traffic to true to avoid a brief downtime due to a race
+between DNS update and Cloudfront distribution creation.   var.cloudfront_route_static_asset_traffic
+should be set to false before setting this variable to false for the same reason.
+A var.cloudfront_logging_bucket and var.cloudfront_acm_certificate_arn also need to be set in
+addition to setting this var to true to enable Cloudfront in front of the Bigeye app stack.
+EOT
+  type        = bool
+  default     = false
+}
+
+variable "cloudfront_route_static_asset_traffic" {
+  description = <<EOT
+This flag controls the DNS entry Bigeye uses for static assets.  Set to true to point DNS at Cloudfront
+for static assets.  See also var.cloudfront_enabled
+EOT
   type        = bool
   default     = false
 }
@@ -2606,4 +2622,10 @@ variable "cloudfront_compression_enabled" {
   description = ""
   type        = bool
   default     = true
+}
+
+variable "cloudfront_origin_read_timeout" {
+  description = "How long Cloudfront waits for a response from the origin (or time Cloudfront will wait for the next packet)"
+  type        = number
+  default     = 60
 }


### PR DESCRIPTION
The current implementation routed all requests through CF.  For API calls in particular this can be a problem as CF has rather short timeouts for API requests.

This creates a separate URL that the app can use just for requesting static assets from Cloudfront.

Other updates in this commit:
- introduce a 2nd flag to allow enable/disable of Cloudfront without a brief outage due to a race between DNS changes and cloudfront distribution creation/deletion
- allow setting Cloudfront request timeout
- set Cloudfront changes to wait for deploy.  This avoids a race with DNS changes when enabling/disabling cloudfront that will lead to downtime (routing to Cloudfront before it has been deployed)