### PR TITLE
feat: add new lineageplus_solr variables

### DIFF
--- a/modules/bigeye/lineageplus.tf
+++ b/modules/bigeye/lineageplus.tf
@@ -24,4 +24,6 @@ module "lineageplus_solr" {
   image_registry   = local.image_registry
   image_repository = "solr${var.lineageplus_solr_image_repository_suffix}"
   image_tag        = var.lineageplus_solr_image_tag
+  solr_opts        = var.lineageplus_solr_opts
+  number_of_tasks  = var.lineageplus_solr_number_of_tasks
 }

--- a/modules/bigeye/lineageplus.tf
+++ b/modules/bigeye/lineageplus.tf
@@ -25,5 +25,5 @@ module "lineageplus_solr" {
   image_repository = "solr${var.lineageplus_solr_image_repository_suffix}"
   image_tag        = var.lineageplus_solr_image_tag
   solr_opts        = var.lineageplus_solr_opts
-  number_of_tasks  = var.lineageplus_solr_number_of_tasks
+  desired_count    = var.lineageplus_solr_desired_count
 }

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2571,12 +2571,12 @@ variable "lineageplus_solr_opts" {
   default     = []
 }
 
-variable "lineageplus_solr_number_of_tasks" {
+variable "lineageplus_solr_desired_count" {
   description = "This variable takes only 0 or 1 and is intended to allow stopping solr service for data volume maintenance."
   type        = number
   default     = 1
   validation {
-    condition     = contains([0, 1], var.lineageplus_solr_number_of_tasks)
+    condition     = contains([0, 1], var.lineageplus_solr_desired_count)
     error_message = "The value must be either 0 or 1."
   }
 }

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2565,6 +2565,22 @@ variable "lineageplus_solr_image_tag" {
   default     = ""
 }
 
+variable "lineageplus_solr_opts" {
+  description = "Additional options to pass to solr startup script."
+  type        = list(string)
+  default     = []
+}
+
+variable "lineageplus_solr_number_of_tasks" {
+  description = "This variable takes only 0 or 1 and is intended to allow stopping solr service for data volume maintenance."
+  type        = number
+  default     = 1
+  validation {
+    condition     = contains([0, 1], var.lineageplus_solr_number_of_tasks)
+    error_message = "The value must be either 0 or 1."
+  }
+}
+
 #======================================================
 # Cloudfront Variables
 #======================================================

--- a/modules/solr-single-instance/main.tf
+++ b/modules/solr-single-instance/main.tf
@@ -309,7 +309,7 @@ resource "aws_ecs_service" "solr" {
   name                              = local.name
   cluster                           = data.aws_ecs_cluster.this.id
   task_definition                   = "${aws_ecs_task_definition.solr.id}:${aws_ecs_task_definition.solr.revision}"
-  desired_count                     = var.number_of_tasks
+  desired_count                     = var.desired_count
   scheduling_strategy               = "REPLICA"
   enable_ecs_managed_tags           = true
   health_check_grace_period_seconds = 60

--- a/modules/solr-single-instance/main.tf
+++ b/modules/solr-single-instance/main.tf
@@ -218,6 +218,12 @@ data "aws_ec2_instance_type" "this" {
   instance_type = var.instance_type
 }
 
+locals {
+  solr_default_opts = [
+    "-Dfile.encoding=UTF-8",
+  ]
+}
+
 resource "aws_ecs_task_definition" "solr" {
   family = local.name
   container_definitions = jsonencode([
@@ -231,6 +237,7 @@ resource "aws_ecs_task_definition" "solr" {
         { name : "SOLR_DATA_HOME", "value" : "/var/solr/data" },
         { name : "SOLR_HEAP", "value" : "4g" },
         { name : "SOLR_PORT", "value" : tostring(var.solr_traffic_port) },
+        { name : "SOLR_OPTS", "value" : join(" ", concat(local.solr_default_opts, var.solr_opts)) },
       ],
       portMappings = [
         {
@@ -302,7 +309,7 @@ resource "aws_ecs_service" "solr" {
   name                              = local.name
   cluster                           = data.aws_ecs_cluster.this.id
   task_definition                   = "${aws_ecs_task_definition.solr.id}:${aws_ecs_task_definition.solr.revision}"
-  desired_count                     = 1
+  desired_count                     = var.number_of_tasks
   scheduling_strategy               = "REPLICA"
   enable_ecs_managed_tags           = true
   health_check_grace_period_seconds = 60

--- a/modules/solr-single-instance/variables.tf
+++ b/modules/solr-single-instance/variables.tf
@@ -126,12 +126,12 @@ variable "solr_opts" {
   default     = []
 }
 
-variable "number_of_tasks" {
+variable "desired_count" {
   description = "This variable takes only 0 or 1 and is intended to allow stopping solr service for data volume maintenance."
   type        = number
   default     = 1
   validation {
-    condition     = contains([0, 1], var.number_of_tasks)
+    condition     = contains([0, 1], var.desired_count)
     error_message = "The value must be either 0 or 1."
   }
 }

--- a/modules/solr-single-instance/variables.tf
+++ b/modules/solr-single-instance/variables.tf
@@ -120,3 +120,18 @@ variable "image_tag" {
   type        = string
 }
 
+variable "solr_opts" {
+  description = "Additional options to pass to solr startup script."
+  type        = list(string)
+  default     = []
+}
+
+variable "number_of_tasks" {
+  description = "This variable takes only 0 or 1 and is intended to allow stopping solr service for data volume maintenance."
+  type        = number
+  default     = 1
+  validation {
+    condition     = contains([0, 1], var.number_of_tasks)
+    error_message = "The value must be either 0 or 1."
+  }
+}


### PR DESCRIPTION
Added new vars:
  - `var.lineageplus_solr_opts` - allows to specify any arguments to be passed to the solr startup script
  -  `var.lineageplus_solr_desired_count` - allows stopping solr without deleting the service.