### PR TITLE
fix: add https:// prefix to static asset root

### DIFF
--- a/modules/bigeye/cloudfront.tf
+++ b/modules/bigeye/cloudfront.tf
@@ -13,7 +13,7 @@ locals {
   cloudfront_ordered_cache_behavior_defaults = {
     target_origin_id           = "bigeye"
     cache_policy_name          = "Managed-CachingOptimized"
-    origin_request_policy_name = "Managed-AllViewer"
+    origin_request_policy_name = "Managed-CORS-CustomOrigin"
     viewer_protocol_policy     = "redirect-to-https"
     compress                   = true
     use_forwarded_values       = false
@@ -31,7 +31,7 @@ module "cloudfront" {
   source = "terraform-aws-modules/cloudfront/aws"
   count  = var.cloudfront_enabled ? 1 : 0
 
-  aliases             = [local.vanity_dns_name]
+  aliases             = [local.static_asset_dns_name]
   comment             = local.name
   enabled             = true
   is_ipv6_enabled     = true
@@ -45,7 +45,7 @@ module "cloudfront" {
 
   origin = {
     bigeye = {
-      domain_name         = module.haproxy.dns_name
+      domain_name         = local.vanity_dns_name
       connection_attempts = 3
       connection_timeout  = 10
       custom_origin_config = {

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -145,7 +145,7 @@ locals {
   web_dns_name                            = "${local.base_dns_alias}-web.${var.top_level_dns_name}"
   web_static_asset_root = (
     var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?
-    module.cloudfront[0].cloudfront_distribution_domain_name : module.haproxy.dns_name
+    module.cloudfront[0].cloudfront_distribution_domain_name : local.vanity_dns_name
   )
   lineageplus_solr_dns_name = "${local.base_dns_alias}-lineageplus-solr.${var.top_level_dns_name}"
 

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -442,7 +442,7 @@ resource "aws_route53_record" "static" {
     name = local.web_static_asset_root
     zone_id = (
       var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?
-      module.cloudfront[0].cloudfront_distribution_hosted_zone_id : module.haproxy.zone_id
+      module.cloudfront[0].cloudfront_distribution_hosted_zone_id : aws_route53_record.apex[0].zone_id
     )
     evaluate_target_health = false
   }
@@ -1161,7 +1161,7 @@ module "web" {
       INSTANCE          = var.instance
       DOCKER_ENV        = var.environment
       APP_ENVIRONMENT   = var.environment
-      STATIC_ASSET_ROOT = local.web_static_asset_root
+      STATIC_ASSET_ROOT = "https://${var.create_dns_records ? aws_route53_record.static[0].fqdn : local.vanity_dns_name}"
       NODE_ENV          = "production"
       PORT              = var.web_port
       DROPWIZARD_HOST   = "https://${local.datawatch_dns_name}"


### PR DESCRIPTION
I missed pushing these changes up before merging
https://github.com/bigeyedata/terraform-modules/pull/425

- add https:// prefix to static asset root
- fix the non-Cloudformation root for static assets to just be the top level address instead of referencing haproxy