### PR TITLE
fix: allow OPTIONS calls for Cloudfront

### DIFF
--- a/modules/bigeye/cloudfront.tf
+++ b/modules/bigeye/cloudfront.tf
@@ -18,8 +18,8 @@ locals {
     viewer_protocol_policy       = "redirect-to-https"
     compress                     = true
     use_forwarded_values         = false
-    allowed_methods              = ["GET", "HEAD"]
-    cached_methods               = ["GET", "HEAD"]
+    allowed_methods              = ["GET", "HEAD", "OPTIONS"]
+    cached_methods               = ["GET", "HEAD", "OPTIONS"]
   }
   cloudfront_ordered_cache_behavior = [
     for path_pattern in local.static_object_path_patterns : merge(


### PR DESCRIPTION
These are not allowed currently and will get blocked during preflight requests for CORS