### PR TITLE
refactor: move route53 records management in simpleservice module

### DIFF
--- a/modules/bigeye/delete_in_the_next_major_version.tf
+++ b/modules/bigeye/delete_in_the_next_major_version.tf
@@ -39,3 +39,8 @@ moved {
   from = aws_route53_record.internalapi[0]
   to   = module.internalapi.aws_route53_record.this[0]
 }
+
+moved {
+  from = aws_route53_record.monocle[0]
+  to   = module.monocle.aws_route53_record.this[0]
+}

--- a/modules/bigeye/delete_in_the_next_major_version.tf
+++ b/modules/bigeye/delete_in_the_next_major_version.tf
@@ -34,3 +34,8 @@ moved {
   from = aws_route53_record.rootcause[0]
   to   = module.rootcause.aws_route53_record.this[0]
 }
+
+moved {
+  from = aws_route53_record.internalapi[0]
+  to   = module.internalapi.aws_route53_record.this[0]
+}

--- a/modules/bigeye/delete_in_the_next_major_version.tf
+++ b/modules/bigeye/delete_in_the_next_major_version.tf
@@ -49,3 +49,8 @@ moved {
   from = aws_route53_record.web[0]
   to   = module.web.aws_route53_record.this[0]
 }
+
+moved {
+  from = aws_route53_record.toretto[0]
+  to   = module.toretto.aws_route53_record.this[0]
+}

--- a/modules/bigeye/delete_in_the_next_major_version.tf
+++ b/modules/bigeye/delete_in_the_next_major_version.tf
@@ -24,3 +24,8 @@ moved {
   from = aws_route53_record.lineagework[0]
   to   = module.lineagework.aws_route53_record.this[0]
 }
+
+moved {
+  from = aws_route53_record.metricwork[0]
+  to   = module.metricwork.aws_route53_record.this[0]
+}

--- a/modules/bigeye/delete_in_the_next_major_version.tf
+++ b/modules/bigeye/delete_in_the_next_major_version.tf
@@ -54,3 +54,8 @@ moved {
   from = aws_route53_record.toretto[0]
   to   = module.toretto.aws_route53_record.this[0]
 }
+
+moved {
+  from = aws_route53_record.scheduler[0]
+  to   = module.scheduler.aws_route53_record.this[0]
+}

--- a/modules/bigeye/delete_in_the_next_major_version.tf
+++ b/modules/bigeye/delete_in_the_next_major_version.tf
@@ -59,3 +59,8 @@ moved {
   from = aws_route53_record.scheduler[0]
   to   = module.scheduler.aws_route53_record.this[0]
 }
+
+moved {
+  from = aws_route53_record.temporalui[0]
+  to   = module.temporalui.aws_route53_record.this[0]
+}

--- a/modules/bigeye/delete_in_the_next_major_version.tf
+++ b/modules/bigeye/delete_in_the_next_major_version.tf
@@ -19,3 +19,8 @@ moved {
   from = aws_route53_record.indexwork[0]
   to   = module.indexwork.aws_route53_record.this[0]
 }
+
+moved {
+  from = aws_route53_record.lineagework[0]
+  to   = module.lineagework.aws_route53_record.this[0]
+}

--- a/modules/bigeye/delete_in_the_next_major_version.tf
+++ b/modules/bigeye/delete_in_the_next_major_version.tf
@@ -29,3 +29,8 @@ moved {
   from = aws_route53_record.metricwork[0]
   to   = module.metricwork.aws_route53_record.this[0]
 }
+
+moved {
+  from = aws_route53_record.rootcause[0]
+  to   = module.rootcause.aws_route53_record.this[0]
+}

--- a/modules/bigeye/delete_in_the_next_major_version.tf
+++ b/modules/bigeye/delete_in_the_next_major_version.tf
@@ -44,3 +44,8 @@ moved {
   from = aws_route53_record.monocle[0]
   to   = module.monocle.aws_route53_record.this[0]
 }
+
+moved {
+  from = aws_route53_record.web[0]
+  to   = module.web.aws_route53_record.this[0]
+}

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -131,7 +131,6 @@ locals {
   temporal_dns_name                       = "${local.base_dns_alias}-workflows.${var.top_level_dns_name}"
   temporalui_dns_name                     = "${local.base_dns_alias}-workflows-admin.${var.top_level_dns_name}"
   temporal_mysql_vanity_dns_name          = "${local.base_dns_alias}-temporal-mysql.${var.top_level_dns_name}"
-  scheduler_dns_name                      = "${local.base_dns_alias}-scheduler.${var.top_level_dns_name}"
   web_static_asset_root = (
     var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?
     module.cloudfront[0].cloudfront_distribution_domain_name : local.vanity_dns_name

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -128,7 +128,6 @@ locals {
   static_asset_dns_name                   = var.use_top_level_dns_apex_as_vanity ? "static.${var.top_level_dns_name}" : "${local.base_dns_alias}-static.${var.top_level_dns_name}"
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"
-  metricwork_dns_name                     = "${local.base_dns_alias}-metricwork.${var.top_level_dns_name}"
   rootcause_dns_name                      = "${local.base_dns_alias}-rootcause.${var.top_level_dns_name}"
   internalapi_dns_name                    = "${local.base_dns_alias}-internalapi.${var.top_level_dns_name}"
   temporal_dns_name                       = "${local.base_dns_alias}-workflows.${var.top_level_dns_name}"

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -129,7 +129,6 @@ locals {
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"
   temporal_dns_name                       = "${local.base_dns_alias}-workflows.${var.top_level_dns_name}"
-  temporalui_dns_name                     = "${local.base_dns_alias}-workflows-admin.${var.top_level_dns_name}"
   temporal_mysql_vanity_dns_name          = "${local.base_dns_alias}-temporal-mysql.${var.top_level_dns_name}"
   web_static_asset_root = (
     var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -128,7 +128,6 @@ locals {
   static_asset_dns_name                   = var.use_top_level_dns_apex_as_vanity ? "static.${var.top_level_dns_name}" : "${local.base_dns_alias}-static.${var.top_level_dns_name}"
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"
-  lineagework_dns_name                    = "${local.base_dns_alias}-lineagework.${var.top_level_dns_name}"
   metricwork_dns_name                     = "${local.base_dns_alias}-metricwork.${var.top_level_dns_name}"
   rootcause_dns_name                      = "${local.base_dns_alias}-rootcause.${var.top_level_dns_name}"
   internalapi_dns_name                    = "${local.base_dns_alias}-internalapi.${var.top_level_dns_name}"

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -128,7 +128,6 @@ locals {
   static_asset_dns_name                   = var.use_top_level_dns_apex_as_vanity ? "static.${var.top_level_dns_name}" : "${local.base_dns_alias}-static.${var.top_level_dns_name}"
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"
-  internalapi_dns_name                    = "${local.base_dns_alias}-internalapi.${var.top_level_dns_name}"
   temporal_dns_name                       = "${local.base_dns_alias}-workflows.${var.top_level_dns_name}"
   temporalui_dns_name                     = "${local.base_dns_alias}-workflows-admin.${var.top_level_dns_name}"
   temporal_mysql_vanity_dns_name          = "${local.base_dns_alias}-temporal-mysql.${var.top_level_dns_name}"

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -128,7 +128,6 @@ locals {
   static_asset_dns_name                   = var.use_top_level_dns_apex_as_vanity ? "static.${var.top_level_dns_name}" : "${local.base_dns_alias}-static.${var.top_level_dns_name}"
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"
-  indexwork_dns_name                      = "${local.base_dns_alias}-indexwork.${var.top_level_dns_name}"
   lineagework_dns_name                    = "${local.base_dns_alias}-lineagework.${var.top_level_dns_name}"
   metricwork_dns_name                     = "${local.base_dns_alias}-metricwork.${var.top_level_dns_name}"
   rootcause_dns_name                      = "${local.base_dns_alias}-rootcause.${var.top_level_dns_name}"

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -126,7 +126,6 @@ locals {
   base_dns_alias                          = coalesce(var.vanity_alias, local.name)
   vanity_dns_name                         = var.use_top_level_dns_apex_as_vanity ? var.top_level_dns_name : "${local.base_dns_alias}.${var.top_level_dns_name}"
   static_asset_dns_name                   = var.use_top_level_dns_apex_as_vanity ? "static.${var.top_level_dns_name}" : "${local.base_dns_alias}-static.${var.top_level_dns_name}"
-  datawatch_dns_name                      = "${local.base_dns_alias}-datawatch.${var.top_level_dns_name}"
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"
   datawork_dns_name                       = "${local.base_dns_alias}-datawork.${var.top_level_dns_name}"

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -131,7 +131,6 @@ locals {
   temporal_dns_name                       = "${local.base_dns_alias}-workflows.${var.top_level_dns_name}"
   temporalui_dns_name                     = "${local.base_dns_alias}-workflows-admin.${var.top_level_dns_name}"
   temporal_mysql_vanity_dns_name          = "${local.base_dns_alias}-temporal-mysql.${var.top_level_dns_name}"
-  monocle_dns_name                        = "${local.base_dns_alias}-monocle.${var.top_level_dns_name}"
   toretto_dns_name                        = "${local.base_dns_alias}-toretto.${var.top_level_dns_name}"
   scheduler_dns_name                      = "${local.base_dns_alias}-scheduler.${var.top_level_dns_name}"
   web_dns_name                            = "${local.base_dns_alias}-web.${var.top_level_dns_name}"

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -133,7 +133,6 @@ locals {
   temporal_mysql_vanity_dns_name          = "${local.base_dns_alias}-temporal-mysql.${var.top_level_dns_name}"
   toretto_dns_name                        = "${local.base_dns_alias}-toretto.${var.top_level_dns_name}"
   scheduler_dns_name                      = "${local.base_dns_alias}-scheduler.${var.top_level_dns_name}"
-  web_dns_name                            = "${local.base_dns_alias}-web.${var.top_level_dns_name}"
   web_static_asset_root = (
     var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?
     module.cloudfront[0].cloudfront_distribution_domain_name : local.vanity_dns_name

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -128,7 +128,6 @@ locals {
   static_asset_dns_name                   = var.use_top_level_dns_apex_as_vanity ? "static.${var.top_level_dns_name}" : "${local.base_dns_alias}-static.${var.top_level_dns_name}"
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"
-  backfillwork_dns_name                   = "${local.base_dns_alias}-backfillwork.${var.top_level_dns_name}"
   indexwork_dns_name                      = "${local.base_dns_alias}-indexwork.${var.top_level_dns_name}"
   lineagework_dns_name                    = "${local.base_dns_alias}-lineagework.${var.top_level_dns_name}"
   metricwork_dns_name                     = "${local.base_dns_alias}-metricwork.${var.top_level_dns_name}"

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -128,7 +128,6 @@ locals {
   static_asset_dns_name                   = var.use_top_level_dns_apex_as_vanity ? "static.${var.top_level_dns_name}" : "${local.base_dns_alias}-static.${var.top_level_dns_name}"
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"
-  datawork_dns_name                       = "${local.base_dns_alias}-datawork.${var.top_level_dns_name}"
   backfillwork_dns_name                   = "${local.base_dns_alias}-backfillwork.${var.top_level_dns_name}"
   indexwork_dns_name                      = "${local.base_dns_alias}-indexwork.${var.top_level_dns_name}"
   lineagework_dns_name                    = "${local.base_dns_alias}-lineagework.${var.top_level_dns_name}"

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -128,7 +128,6 @@ locals {
   static_asset_dns_name                   = var.use_top_level_dns_apex_as_vanity ? "static.${var.top_level_dns_name}" : "${local.base_dns_alias}-static.${var.top_level_dns_name}"
   datawatch_mysql_vanity_dns_name         = "${local.base_dns_alias}-mysql.${var.top_level_dns_name}"
   datawatch_mysql_replica_vanity_dns_name = "${local.base_dns_alias}-mysql-ro.${var.top_level_dns_name}"
-  rootcause_dns_name                      = "${local.base_dns_alias}-rootcause.${var.top_level_dns_name}"
   internalapi_dns_name                    = "${local.base_dns_alias}-internalapi.${var.top_level_dns_name}"
   temporal_dns_name                       = "${local.base_dns_alias}-workflows.${var.top_level_dns_name}"
   temporalui_dns_name                     = "${local.base_dns_alias}-workflows-admin.${var.top_level_dns_name}"

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -131,7 +131,6 @@ locals {
   temporal_dns_name                       = "${local.base_dns_alias}-workflows.${var.top_level_dns_name}"
   temporalui_dns_name                     = "${local.base_dns_alias}-workflows-admin.${var.top_level_dns_name}"
   temporal_mysql_vanity_dns_name          = "${local.base_dns_alias}-temporal-mysql.${var.top_level_dns_name}"
-  toretto_dns_name                        = "${local.base_dns_alias}-toretto.${var.top_level_dns_name}"
   scheduler_dns_name                      = "${local.base_dns_alias}-scheduler.${var.top_level_dns_name}"
   web_static_asset_root = (
     var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ?

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1089,6 +1089,7 @@ module "web" {
   create_dns_records = var.create_dns_records
   route53_zone_id    = data.aws_route53_zone.this[0].zone_id
   dns_name           = "${local.base_dns_alias}-web.${var.top_level_dns_name}"
+  route53_record_ttl = 300
 }
 
 #======================================================
@@ -1340,6 +1341,7 @@ module "monocle" {
   create_dns_records = var.create_dns_records
   route53_zone_id    = data.aws_route53_zone.this[0].zone_id
   dns_name           = "${local.base_dns_alias}-monocle.${var.top_level_dns_name}"
+  route53_record_ttl = 300
 }
 
 resource "aws_appautoscaling_target" "monocle" {

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -475,15 +475,6 @@ resource "aws_route53_record" "backfillwork" {
   records = [module.backfillwork.lb_dns_name]
 }
 
-resource "aws_route53_record" "datawork" {
-  count   = var.create_dns_records ? 1 : 0
-  zone_id = data.aws_route53_zone.this[0].zone_id
-  name    = local.datawork_dns_name
-  type    = "CNAME"
-  ttl     = 3600
-  records = [module.datawork.lb_dns_name]
-}
-
 resource "aws_route53_record" "indexwork" {
   count   = var.create_dns_records ? 1 : 0
   zone_id = data.aws_route53_zone.this[0].zone_id
@@ -762,7 +753,7 @@ module "bigeye_admin" {
   temporal_domain_name     = local.temporal_dns_name
   temporalui_domain_name   = local.temporalui_dns_name
   datawatch_domain_name    = module.datawatch.dns_name
-  datawork_domain_name     = local.datawork_dns_name
+  datawork_domain_name     = module.datawork.dns_name
   backfillwork_domain_name = local.backfillwork_dns_name
   indexwork_domain_name    = local.indexwork_dns_name
   lineagework_domain_name  = local.lineagework_dns_name
@@ -2437,6 +2428,10 @@ module "datawork" {
   )
 
   secret_arns = local.datawatch_secret_arns
+
+  create_dns_records = var.create_dns_records
+  route53_zone_id    = data.aws_route53_zone.this[0].zone_id
+  dns_name           = "${local.base_dns_alias}-datawork.${var.top_level_dns_name}"
 }
 
 module "backfillwork" {

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -466,15 +466,6 @@ resource "aws_route53_record" "datawatch_mysql_replica" {
   records = [module.datawatch_rds.replica_dns_name]
 }
 
-resource "aws_route53_record" "indexwork" {
-  count   = var.create_dns_records ? 1 : 0
-  zone_id = data.aws_route53_zone.this[0].zone_id
-  name    = local.indexwork_dns_name
-  type    = "CNAME"
-  ttl     = 3600
-  records = [module.indexwork.lb_dns_name]
-}
-
 resource "aws_route53_record" "lineagework" {
   count   = var.create_dns_records ? 1 : 0
   zone_id = data.aws_route53_zone.this[0].zone_id
@@ -746,7 +737,7 @@ module "bigeye_admin" {
   datawatch_domain_name    = module.datawatch.dns_name
   datawork_domain_name     = module.datawork.dns_name
   backfillwork_domain_name = module.backfillwork.dns_name
-  indexwork_domain_name    = local.indexwork_dns_name
+  indexwork_domain_name    = module.indexwork.dns_name
   lineagework_domain_name  = local.lineagework_dns_name
   metricwork_domain_name   = local.metricwork_dns_name
   rootcause_domain_name    = local.rootcause_dns_name
@@ -2594,6 +2585,10 @@ module "indexwork" {
   )
 
   secret_arns = local.datawatch_secret_arns
+
+  create_dns_records = var.create_dns_records
+  route53_zone_id    = data.aws_route53_zone.this[0].zone_id
+  dns_name           = "${local.base_dns_alias}-indexwork.${var.top_level_dns_name}"
 }
 
 module "lineagework" {

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -466,15 +466,6 @@ resource "aws_route53_record" "datawatch_mysql_replica" {
   records = [module.datawatch_rds.replica_dns_name]
 }
 
-resource "aws_route53_record" "web" {
-  count   = var.create_dns_records ? 1 : 0
-  zone_id = data.aws_route53_zone.this[0].zone_id
-  name    = local.web_dns_name
-  type    = "CNAME"
-  ttl     = 300
-  records = [module.web.lb_dns_name]
-}
-
 resource "aws_route53_record" "toretto" {
   count   = var.create_dns_records ? 1 : 0
   zone_id = data.aws_route53_zone.this[0].zone_id
@@ -684,7 +675,7 @@ module "bigeye_admin" {
   stack_name = local.name
 
   haproxy_domain_name      = local.vanity_dns_name
-  web_domain_name          = local.web_dns_name
+  web_domain_name          = module.web.dns_name
   monocle_domain_name      = module.monocle.dns_name
   toretto_domain_name      = local.toretto_dns_name
   temporal_domain_name     = local.temporal_dns_name
@@ -989,7 +980,7 @@ module "haproxy" {
       TORETTO_PORT     = "443"
       MONOCLE_HOST     = module.monocle.dns_name
       MONOCLE_PORT     = "443"
-      WEB_HOST         = local.web_dns_name
+      WEB_HOST         = module.web.dns_name
       WEB_PORT         = "443"
       REDIRECT_ADDRESS = "https://${local.vanity_dns_name}"
       PORT             = var.haproxy_port
@@ -1094,6 +1085,10 @@ module "web" {
     local.sentry_dsn_secret_map,
     var.web_additional_secret_arns
   )
+
+  create_dns_records = var.create_dns_records
+  route53_zone_id    = data.aws_route53_zone.this[0].zone_id
+  dns_name           = "${local.base_dns_alias}-web.${var.top_level_dns_name}"
 }
 
 #======================================================

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -466,15 +466,6 @@ resource "aws_route53_record" "datawatch_mysql_replica" {
   records = [module.datawatch_rds.replica_dns_name]
 }
 
-resource "aws_route53_record" "temporalui" {
-  count   = var.create_dns_records ? 1 : 0
-  zone_id = data.aws_route53_zone.this[0].zone_id
-  name    = local.temporalui_dns_name
-  type    = "CNAME"
-  ttl     = 300
-  records = [module.temporalui.lb_dns_name]
-}
-
 resource "aws_route53_record" "temporal" {
   count   = var.create_dns_records ? 1 : 0
   zone_id = data.aws_route53_zone.this[0].zone_id
@@ -661,7 +652,7 @@ module "bigeye_admin" {
   monocle_domain_name      = module.monocle.dns_name
   toretto_domain_name      = module.toretto.dns_name
   temporal_domain_name     = local.temporal_dns_name
-  temporalui_domain_name   = local.temporalui_dns_name
+  temporalui_domain_name   = module.temporalui.dns_name
   datawatch_domain_name    = module.datawatch.dns_name
   datawork_domain_name     = module.datawork.dns_name
   backfillwork_domain_name = module.backfillwork.dns_name

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -427,7 +427,7 @@ resource "aws_route53_record" "apex" {
   name    = local.vanity_dns_name
   type    = "A"
   alias {
-    name                   = module.haproxy.dns_name
+    name                   = module.haproxy.lb_dns_name
     zone_id                = module.haproxy.zone_id
     evaluate_target_health = false
   }
@@ -446,15 +446,6 @@ resource "aws_route53_record" "static" {
     )
     evaluate_target_health = false
   }
-}
-
-resource "aws_route53_record" "datawatch" {
-  count   = var.create_dns_records ? 1 : 0
-  zone_id = data.aws_route53_zone.this[0].zone_id
-  name    = local.datawatch_dns_name
-  type    = "CNAME"
-  ttl     = 3600
-  records = [module.datawatch.dns_name]
 }
 
 resource "aws_route53_record" "datawatch_mysql" {
@@ -481,7 +472,7 @@ resource "aws_route53_record" "backfillwork" {
   name    = local.backfillwork_dns_name
   type    = "CNAME"
   ttl     = 3600
-  records = [module.backfillwork.dns_name]
+  records = [module.backfillwork.lb_dns_name]
 }
 
 resource "aws_route53_record" "datawork" {
@@ -490,7 +481,7 @@ resource "aws_route53_record" "datawork" {
   name    = local.datawork_dns_name
   type    = "CNAME"
   ttl     = 3600
-  records = [module.datawork.dns_name]
+  records = [module.datawork.lb_dns_name]
 }
 
 resource "aws_route53_record" "indexwork" {
@@ -499,7 +490,7 @@ resource "aws_route53_record" "indexwork" {
   name    = local.indexwork_dns_name
   type    = "CNAME"
   ttl     = 3600
-  records = [module.indexwork.dns_name]
+  records = [module.indexwork.lb_dns_name]
 }
 
 resource "aws_route53_record" "lineagework" {
@@ -508,7 +499,7 @@ resource "aws_route53_record" "lineagework" {
   name    = local.lineagework_dns_name
   type    = "CNAME"
   ttl     = 3600
-  records = [module.lineagework.dns_name]
+  records = [module.lineagework.lb_dns_name]
 }
 
 resource "aws_route53_record" "metricwork" {
@@ -517,7 +508,7 @@ resource "aws_route53_record" "metricwork" {
   name    = local.metricwork_dns_name
   type    = "CNAME"
   ttl     = 3600
-  records = [module.metricwork.dns_name]
+  records = [module.metricwork.lb_dns_name]
 }
 
 resource "aws_route53_record" "rootcause" {
@@ -526,7 +517,7 @@ resource "aws_route53_record" "rootcause" {
   name    = local.rootcause_dns_name
   type    = "CNAME"
   ttl     = 3600
-  records = [module.rootcause.dns_name]
+  records = [module.rootcause.lb_dns_name]
 }
 
 resource "aws_route53_record" "monocle" {
@@ -535,7 +526,7 @@ resource "aws_route53_record" "monocle" {
   name    = local.monocle_dns_name
   type    = "CNAME"
   ttl     = 300
-  records = [module.monocle.dns_name]
+  records = [module.monocle.lb_dns_name]
 }
 
 resource "aws_route53_record" "internalapi" {
@@ -544,7 +535,7 @@ resource "aws_route53_record" "internalapi" {
   name    = local.internalapi_dns_name
   type    = "CNAME"
   ttl     = 3600
-  records = [module.internalapi.dns_name]
+  records = [module.internalapi.lb_dns_name]
 }
 
 resource "aws_route53_record" "web" {
@@ -553,7 +544,7 @@ resource "aws_route53_record" "web" {
   name    = local.web_dns_name
   type    = "CNAME"
   ttl     = 300
-  records = [module.web.dns_name]
+  records = [module.web.lb_dns_name]
 }
 
 resource "aws_route53_record" "toretto" {
@@ -562,7 +553,7 @@ resource "aws_route53_record" "toretto" {
   name    = local.toretto_dns_name
   type    = "CNAME"
   ttl     = 300
-  records = [module.toretto.dns_name]
+  records = [module.toretto.lb_dns_name]
 }
 
 resource "aws_route53_record" "scheduler" {
@@ -571,7 +562,7 @@ resource "aws_route53_record" "scheduler" {
   name    = local.scheduler_dns_name
   type    = "CNAME"
   ttl     = 3600
-  records = [module.scheduler.dns_name]
+  records = [module.scheduler.lb_dns_name]
 }
 
 resource "aws_route53_record" "temporalui" {
@@ -580,7 +571,7 @@ resource "aws_route53_record" "temporalui" {
   name    = local.temporalui_dns_name
   type    = "CNAME"
   ttl     = 300
-  records = [module.temporalui.dns_name]
+  records = [module.temporalui.lb_dns_name]
 }
 
 resource "aws_route53_record" "temporal" {
@@ -770,7 +761,7 @@ module "bigeye_admin" {
   toretto_domain_name      = local.toretto_dns_name
   temporal_domain_name     = local.temporal_dns_name
   temporalui_domain_name   = local.temporalui_dns_name
-  datawatch_domain_name    = local.datawatch_dns_name
+  datawatch_domain_name    = module.datawatch.dns_name
   datawork_domain_name     = local.datawork_dns_name
   backfillwork_domain_name = local.backfillwork_dns_name
   indexwork_domain_name    = local.indexwork_dns_name
@@ -1062,7 +1053,7 @@ module "haproxy" {
     {
       ENVIRONMENT      = var.environment
       INSTANCE         = var.instance
-      DW_HOST          = local.datawatch_dns_name
+      DW_HOST          = module.datawatch.dns_name
       DW_PORT          = "443"
       SCHEDULER_HOST   = local.scheduler_dns_name
       SCHEDULER_PORT   = "443"
@@ -1164,8 +1155,8 @@ module "web" {
       STATIC_ASSET_ROOT = "https://${var.create_dns_records ? aws_route53_record.static[0].fqdn : local.vanity_dns_name}"
       NODE_ENV          = "production"
       PORT              = var.web_port
-      DROPWIZARD_HOST   = "https://${local.datawatch_dns_name}"
-      DATAWATCH_ADDRESS = "https://${local.datawatch_dns_name}"
+      DROPWIZARD_HOST   = "https://${module.datawatch.dns_name}"
+      DATAWATCH_ADDRESS = "https://${module.datawatch.dns_name}"
       MAX_NODE_MEM_MB   = "4096"
     },
     var.web_additional_environment_vars,
@@ -2335,6 +2326,10 @@ module "datawatch" {
   )
 
   secret_arns = local.datawatch_secret_arns
+
+  create_dns_records = var.create_dns_records
+  route53_zone_id    = data.aws_route53_zone.this[0].zone_id
+  dns_name           = "${local.base_dns_alias}-datawatch.${var.top_level_dns_name}"
 }
 
 module "datawork" {

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -466,15 +466,6 @@ resource "aws_route53_record" "datawatch_mysql_replica" {
   records = [module.datawatch_rds.replica_dns_name]
 }
 
-resource "aws_route53_record" "lineagework" {
-  count   = var.create_dns_records ? 1 : 0
-  zone_id = data.aws_route53_zone.this[0].zone_id
-  name    = local.lineagework_dns_name
-  type    = "CNAME"
-  ttl     = 3600
-  records = [module.lineagework.lb_dns_name]
-}
-
 resource "aws_route53_record" "metricwork" {
   count   = var.create_dns_records ? 1 : 0
   zone_id = data.aws_route53_zone.this[0].zone_id
@@ -738,7 +729,7 @@ module "bigeye_admin" {
   datawork_domain_name     = module.datawork.dns_name
   backfillwork_domain_name = module.backfillwork.dns_name
   indexwork_domain_name    = module.indexwork.dns_name
-  lineagework_domain_name  = local.lineagework_dns_name
+  lineagework_domain_name  = module.lineagework.dns_name
   metricwork_domain_name   = local.metricwork_dns_name
   rootcause_domain_name    = local.rootcause_dns_name
   internalapi_domain_name  = local.internalapi_dns_name
@@ -2676,6 +2667,10 @@ module "lineagework" {
   )
 
   secret_arns = local.datawatch_secret_arns
+
+  create_dns_records = var.create_dns_records
+  route53_zone_id    = data.aws_route53_zone.this[0].zone_id
+  dns_name           = "${local.base_dns_alias}-lineagework.${var.top_level_dns_name}"
 }
 
 module "metricwork" {

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -466,15 +466,6 @@ resource "aws_route53_record" "datawatch_mysql_replica" {
   records = [module.datawatch_rds.replica_dns_name]
 }
 
-resource "aws_route53_record" "backfillwork" {
-  count   = var.create_dns_records ? 1 : 0
-  zone_id = data.aws_route53_zone.this[0].zone_id
-  name    = local.backfillwork_dns_name
-  type    = "CNAME"
-  ttl     = 3600
-  records = [module.backfillwork.lb_dns_name]
-}
-
 resource "aws_route53_record" "indexwork" {
   count   = var.create_dns_records ? 1 : 0
   zone_id = data.aws_route53_zone.this[0].zone_id
@@ -754,7 +745,7 @@ module "bigeye_admin" {
   temporalui_domain_name   = local.temporalui_dns_name
   datawatch_domain_name    = module.datawatch.dns_name
   datawork_domain_name     = module.datawork.dns_name
-  backfillwork_domain_name = local.backfillwork_dns_name
+  backfillwork_domain_name = module.backfillwork.dns_name
   indexwork_domain_name    = local.indexwork_dns_name
   lineagework_domain_name  = local.lineagework_dns_name
   metricwork_domain_name   = local.metricwork_dns_name
@@ -2514,6 +2505,10 @@ module "backfillwork" {
     var.backfillwork_additional_environment_vars,
   )
   secret_arns = local.datawatch_secret_arns
+
+  create_dns_records = var.create_dns_records
+  route53_zone_id    = data.aws_route53_zone.this[0].zone_id
+  dns_name           = "${local.base_dns_alias}-backfillwork.${var.top_level_dns_name}"
 }
 
 module "indexwork" {

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -466,15 +466,6 @@ resource "aws_route53_record" "datawatch_mysql_replica" {
   records = [module.datawatch_rds.replica_dns_name]
 }
 
-resource "aws_route53_record" "metricwork" {
-  count   = var.create_dns_records ? 1 : 0
-  zone_id = data.aws_route53_zone.this[0].zone_id
-  name    = local.metricwork_dns_name
-  type    = "CNAME"
-  ttl     = 3600
-  records = [module.metricwork.lb_dns_name]
-}
-
 resource "aws_route53_record" "rootcause" {
   count   = var.create_dns_records ? 1 : 0
   zone_id = data.aws_route53_zone.this[0].zone_id
@@ -730,7 +721,7 @@ module "bigeye_admin" {
   backfillwork_domain_name = module.backfillwork.dns_name
   indexwork_domain_name    = module.indexwork.dns_name
   lineagework_domain_name  = module.lineagework.dns_name
-  metricwork_domain_name   = local.metricwork_dns_name
+  metricwork_domain_name   = module.metricwork.dns_name
   rootcause_domain_name    = local.rootcause_dns_name
   internalapi_domain_name  = local.internalapi_dns_name
   scheduler_domain_name    = local.scheduler_dns_name
@@ -2755,6 +2746,10 @@ module "metricwork" {
   )
 
   secret_arns = local.datawatch_secret_arns
+
+  create_dns_records = var.create_dns_records
+  route53_zone_id    = data.aws_route53_zone.this[0].zone_id
+  dns_name           = "${local.base_dns_alias}-metricwork.${var.top_level_dns_name}"
 }
 
 module "rootcause" {

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -466,15 +466,6 @@ resource "aws_route53_record" "datawatch_mysql_replica" {
   records = [module.datawatch_rds.replica_dns_name]
 }
 
-resource "aws_route53_record" "rootcause" {
-  count   = var.create_dns_records ? 1 : 0
-  zone_id = data.aws_route53_zone.this[0].zone_id
-  name    = local.rootcause_dns_name
-  type    = "CNAME"
-  ttl     = 3600
-  records = [module.rootcause.lb_dns_name]
-}
-
 resource "aws_route53_record" "monocle" {
   count   = var.create_dns_records ? 1 : 0
   zone_id = data.aws_route53_zone.this[0].zone_id
@@ -722,7 +713,7 @@ module "bigeye_admin" {
   indexwork_domain_name    = module.indexwork.dns_name
   lineagework_domain_name  = module.lineagework.dns_name
   metricwork_domain_name   = module.metricwork.dns_name
-  rootcause_domain_name    = local.rootcause_dns_name
+  rootcause_domain_name    = module.rootcause.dns_name
   internalapi_domain_name  = local.internalapi_dns_name
   scheduler_domain_name    = local.scheduler_dns_name
 
@@ -2835,6 +2826,10 @@ module "rootcause" {
   )
 
   secret_arns = local.datawatch_secret_arns
+
+  create_dns_records = var.create_dns_records
+  route53_zone_id    = data.aws_route53_zone.this[0].zone_id
+  dns_name           = "${local.base_dns_alias}-rootcause.${var.top_level_dns_name}"
 }
 
 module "internalapi" {

--- a/modules/bigeye/moved.tf
+++ b/modules/bigeye/moved.tf
@@ -14,3 +14,8 @@ moved {
   from = aws_route53_record.backfillwork[0]
   to   = module.backfillwork.aws_route53_record.this[0]
 }
+
+moved {
+  from = aws_route53_record.indexwork[0]
+  to   = module.indexwork.aws_route53_record.this[0]
+}

--- a/modules/bigeye/moved.tf
+++ b/modules/bigeye/moved.tf
@@ -7,5 +7,10 @@ moved {
 
 moved {
   from = aws_route53_record.datawork[0]
-  to = module.datawork.aws_route53_record.this[0]
+  to   = module.datawork.aws_route53_record.this[0]
+}
+
+moved {
+  from = aws_route53_record.backfillwork[0]
+  to   = module.backfillwork.aws_route53_record.this[0]
 }

--- a/modules/bigeye/moved.tf
+++ b/modules/bigeye/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = aws_route53_record.datawatch[0]
+  to   = module.datawatch.aws_route53_record.this[0]
+}

--- a/modules/bigeye/moved.tf
+++ b/modules/bigeye/moved.tf
@@ -1,4 +1,11 @@
+# This file will be deleted with the next major version release of this module
+
 moved {
   from = aws_route53_record.datawatch[0]
   to   = module.datawatch.aws_route53_record.this[0]
+}
+
+moved {
+  from = aws_route53_record.datawork[0]
+  to = module.datawork.aws_route53_record.this[0]
 }

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -176,7 +176,7 @@ output "metricwork_load_balancer_zone_id" {
 
 output "rootcause_dns_name" {
   description = "DNS name for the rootcause service"
-  value       = local.rootcause_dns_name
+  value       = module.rootcause.dns_name
 }
 
 output "rootcause_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -146,7 +146,7 @@ output "indexwork_load_balancer_zone_id" {
 
 output "lineagework_dns_name" {
   description = "DNS name for the lineagework service"
-  value       = local.lineagework_dns_name
+  value       = module.lineagework.dns_name
 }
 
 output "lineagework_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -116,7 +116,7 @@ output "backfillwork_load_balancer_zone_id" {
 
 output "datawork_dns_name" {
   description = "DNS name for the datawork service"
-  value       = local.datawork_dns_name
+  value       = module.datawork.dns_name
 }
 
 output "datawork_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -281,7 +281,7 @@ output "toretto_load_balancer_zone_id" {
 
 output "web_dns_name" {
   description = "DNS name for the web service"
-  value       = local.web_dns_name
+  value       = module.web.dns_name
 }
 
 output "web_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -131,7 +131,7 @@ output "datawork_load_balancer_zone_id" {
 
 output "indexwork_dns_name" {
   description = "DNS name for the indexwork service"
-  value       = local.indexwork_dns_name
+  value       = module.indexwork.dns_name
 }
 
 output "indexwork_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -13,7 +13,7 @@ output "vanity_dns_name" {
 
 output "haproxy_load_balancer_dns_name" {
   description = "The dns name of the HAProxy load balancer"
-  value       = module.haproxy.dns_name
+  value       = module.haproxy.lb_dns_name
 }
 
 output "haproxy_load_balancer_zone_id" {
@@ -86,12 +86,12 @@ output "temporal_database_dns_name" {
 #======================================================
 output "datawatch_dns_name" {
   description = "DNS name for the datawatch service"
-  value       = local.datawatch_dns_name
+  value       = module.datawatch.dns_name
 }
 
 output "datawatch_load_balancer_dns_name" {
   description = "The dns name of the datawatch load balancer"
-  value       = module.datawatch.dns_name
+  value       = module.datawatch.lb_dns_name
 }
 
 output "datawatch_load_balancer_zone_id" {
@@ -106,7 +106,7 @@ output "backfillwork_dns_name" {
 
 output "backfillwork_load_balancer_dns_name" {
   description = "The dns name of the backfillwork load balancer"
-  value       = module.backfillwork.dns_name
+  value       = module.backfillwork.lb_dns_name
 }
 
 output "backfillwork_load_balancer_zone_id" {
@@ -121,7 +121,7 @@ output "datawork_dns_name" {
 
 output "datawork_load_balancer_dns_name" {
   description = "The dns name of the datawork load balancer"
-  value       = module.datawork.dns_name
+  value       = module.datawork.lb_dns_name
 }
 
 output "datawork_load_balancer_zone_id" {
@@ -136,7 +136,7 @@ output "indexwork_dns_name" {
 
 output "indexwork_load_balancer_dns_name" {
   description = "The dns name of the indexwork load balancer"
-  value       = module.indexwork.dns_name
+  value       = module.indexwork.lb_dns_name
 }
 
 output "indexwork_load_balancer_zone_id" {
@@ -151,7 +151,7 @@ output "lineagework_dns_name" {
 
 output "lineagework_load_balancer_dns_name" {
   description = "The dns name of the lineagework load balancer"
-  value       = module.lineagework.dns_name
+  value       = module.lineagework.lb_dns_name
 }
 
 output "lineagework_load_balancer_zone_id" {
@@ -166,7 +166,7 @@ output "metricwork_dns_name" {
 
 output "metricwork_load_balancer_dns_name" {
   description = "The dns name of the metricwork load balancer"
-  value       = module.metricwork.dns_name
+  value       = module.metricwork.lb_dns_name
 }
 
 output "metricwork_load_balancer_zone_id" {
@@ -181,7 +181,7 @@ output "rootcause_dns_name" {
 
 output "rootcause_load_balancer_dns_name" {
   description = "The dns name of the rootcause load balancer"
-  value       = module.rootcause.dns_name
+  value       = module.rootcause.lb_dns_name
 }
 
 output "rootcause_load_balancer_zone_id" {
@@ -196,7 +196,7 @@ output "monocle_dns_name" {
 
 output "monocle_load_balancer_dns_name" {
   description = "The dns name of the monocle load balancer"
-  value       = module.monocle.dns_name
+  value       = module.monocle.lb_dns_name
 }
 
 output "monocle_load_balancer_zone_id" {
@@ -211,7 +211,7 @@ output "internalapi_dns_name" {
 
 output "internalapi_load_balancer_dns_name" {
   description = "The dns name of the internalapi load balancer"
-  value       = module.internalapi.dns_name
+  value       = module.internalapi.lb_dns_name
 }
 
 output "internalapi_load_balancer_zone_id" {
@@ -226,7 +226,7 @@ output "scheduler_dns_name" {
 
 output "scheduler_load_balancer_dns_name" {
   description = "The dns name of the scheduler load balancer"
-  value       = module.scheduler.dns_name
+  value       = module.scheduler.lb_dns_name
 }
 
 output "scheduler_load_balancer_zone_id" {
@@ -256,7 +256,7 @@ output "temporalui_dns_name" {
 
 output "temporalui_load_balancer_dns_name" {
   description = "The dns name of the temporal user interface service load balancer"
-  value       = module.temporalui.dns_name
+  value       = module.temporalui.lb_dns_name
 }
 
 output "temporalui_load_balancer_zone_id" {
@@ -271,7 +271,7 @@ output "toretto_dns_name" {
 
 output "toretto_load_balancer_dns_name" {
   description = "The dns name of the toretto load balancer"
-  value       = module.toretto.dns_name
+  value       = module.toretto.lb_dns_name
 }
 
 output "toretto_load_balancer_zone_id" {
@@ -286,7 +286,7 @@ output "web_dns_name" {
 
 output "web_load_balancer_dns_name" {
   description = "The dns name of the web load balancer"
-  value       = module.web.dns_name
+  value       = module.web.lb_dns_name
 }
 
 output "web_load_balancer_zone_id" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -191,7 +191,7 @@ output "rootcause_load_balancer_zone_id" {
 
 output "monocle_dns_name" {
   description = "DNS name for the monocle service"
-  value       = local.monocle_dns_name
+  value       = module.monocle.dns_name
 }
 
 output "monocle_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -101,7 +101,7 @@ output "datawatch_load_balancer_zone_id" {
 
 output "backfillwork_dns_name" {
   description = "DNS name for the backfillwork service"
-  value       = local.backfillwork_dns_name
+  value       = module.backfillwork.dns_name
 }
 
 output "backfillwork_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -161,7 +161,7 @@ output "lineagework_load_balancer_zone_id" {
 
 output "metricwork_dns_name" {
   description = "DNS name for the metricwork service"
-  value       = local.metricwork_dns_name
+  value       = module.metricwork.dns_name
 }
 
 output "metricwork_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -251,7 +251,7 @@ output "temporal_load_balancer_zone_id" {
 
 output "temporalui_dns_name" {
   description = "DNS name for the temporal user interface"
-  value       = local.temporalui_dns_name
+  value       = module.temporalui.dns_name
 }
 
 output "temporalui_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -266,7 +266,7 @@ output "temporalui_load_balancer_zone_id" {
 
 output "toretto_dns_name" {
   description = "DNS name for the toretto service"
-  value       = local.toretto_dns_name
+  value       = module.toretto.dns_name
 }
 
 output "toretto_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -221,7 +221,7 @@ output "internalapi_load_balancer_zone_id" {
 
 output "scheduler_dns_name" {
   description = "DNS name for the scheduler service"
-  value       = local.scheduler_dns_name
+  value       = module.scheduler.dns_name
 }
 
 output "scheduler_load_balancer_dns_name" {

--- a/modules/bigeye/outputs.tf
+++ b/modules/bigeye/outputs.tf
@@ -206,7 +206,7 @@ output "monocle_load_balancer_zone_id" {
 
 output "internalapi_dns_name" {
   description = "DNS name for the internalapi service"
-  value       = local.internalapi_dns_name
+  value       = module.internalapi.dns_name
 }
 
 output "internalapi_load_balancer_dns_name" {

--- a/modules/bigeye/temporal.tf
+++ b/modules/bigeye/temporal.tf
@@ -753,7 +753,8 @@ module "temporalui" {
 
   create_dns_records = var.create_dns_records
   route53_zone_id    = data.aws_route53_zone.this[0].zone_id
-  dns_name           = "${local.base_dns_alias}-temporalui.${var.top_level_dns_name}"
+  dns_name           = "${local.base_dns_alias}-workflows-admin.${var.top_level_dns_name}"
+  route53_record_ttl = 300
 }
 
 #======================================================

--- a/modules/bigeye/temporal.tf
+++ b/modules/bigeye/temporal.tf
@@ -750,6 +750,10 @@ module "temporalui" {
   awsfirelens_host    = var.awsfirelens_host
   awsfirelens_image   = var.awsfirelens_image
   awsfirelens_uri     = var.awsfirelens_uri
+
+  create_dns_records = var.create_dns_records
+  route53_zone_id    = data.aws_route53_zone.this[0].zone_id
+  dns_name           = "${local.base_dns_alias}-temporalui.${var.top_level_dns_name}"
 }
 
 #======================================================

--- a/modules/simpleservice/main.tf
+++ b/modules/simpleservice/main.tf
@@ -315,7 +315,7 @@ resource "aws_route53_record" "this" {
   zone_id = var.route53_zone_id
   name    = var.dns_name
   type    = "CNAME"
-  ttl     = 3600
+  ttl     = var.route53_record_ttl
   records = [aws_lb.this.dns_name]
 }
 

--- a/modules/simpleservice/main.tf
+++ b/modules/simpleservice/main.tf
@@ -310,3 +310,12 @@ resource "aws_ecs_service" "controlled_count" {
   tags = var.tags
 }
 
+resource "aws_route53_record" "this" {
+  count   = var.create_dns_records ? 1 : 0
+  zone_id = var.route53_zone_id
+  name    = var.dns_name
+  type    = "CNAME"
+  ttl     = 3600
+  records = [aws_lb.this.dns_name]
+}
+

--- a/modules/simpleservice/outputs.tf
+++ b/modules/simpleservice/outputs.tf
@@ -3,9 +3,14 @@ output "ecs_service_arn" {
   value       = var.control_desired_count ? aws_ecs_service.controlled_count[0].id : aws_ecs_service.uncontrolled_count[0].id
 }
 
-output "dns_name" {
+output "lb_dns_name" {
   description = "The DNS name of the load balancer"
   value       = aws_lb.this.dns_name
+}
+
+output "dns_name" {
+  description = "The DNS name of the service"
+  value       = var.create_dns_records ? aws_route53_record.this[0].name : var.dns_name
 }
 
 output "load_balancer_full_name" {

--- a/modules/simpleservice/variables.tf
+++ b/modules/simpleservice/variables.tf
@@ -401,11 +401,17 @@ variable "dns_name" {
     Service DNS name. It will be used to create a CNAME pointing at the LB
     If var.create_dns_records = false this name will be directly plugged in the output.dns_name
   EOD
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "route53_zone_id" {
   description = "ID of the route53 zone in which RRs should be created. "
-  default = ""
+  default     = ""
+}
+
+variable "route53_record_ttl" {
+  description = "TTL for dns_name record"
+  type        = number
+  default     = 3600
 }

--- a/modules/simpleservice/variables.tf
+++ b/modules/simpleservice/variables.tf
@@ -389,3 +389,23 @@ variable "lb_deregistration_delay" {
   type        = number
   default     = 60
 }
+
+variable "create_dns_records" {
+  description = "Whether to set up DNS records"
+  type        = bool
+  default     = false
+}
+
+variable "dns_name" {
+  description = <<EOD
+    Service DNS name. It will be used to create a CNAME pointing at the LB
+    If var.create_dns_records = false this name will be directly plugged in the output.dns_name
+  EOD
+  type = string
+  default = ""
+}
+
+variable "route53_zone_id" {
+  description = "ID of the route53 zone in which RRs should be created. "
+  default = ""
+}


### PR DESCRIPTION
This will unify DNS CNAME management and will reduce the amount of copy-pasted resources required to add a new service.