### PR TITLE
fix: fix missing tags for ECS solr instance

### DIFF
--- a/modules/bigeye/lineageplus.tf
+++ b/modules/bigeye/lineageplus.tf
@@ -3,9 +3,12 @@ module "lineageplus_solr" {
   source            = "../solr-single-instance"
   subnet_id         = local.application_subnet_ids[0]
   lb_subnet_ids     = local.public_alb_subnet_ids
-  instance          = local.name
-  name              = "solr"
+  app               = "solr"
+  instance          = var.instance
+  stack             = local.name
+  name              = "${local.name}-solr"
   vpc_id            = local.vpc_id
+  tags              = local.tags
   ecs_cluster_name  = aws_ecs_cluster.this.name
   availability_zone = local.vpc_availability_zones[0]
   instance_type     = var.lineageplus_solr_instance_type

--- a/modules/solr-single-instance/variables.tf
+++ b/modules/solr-single-instance/variables.tf
@@ -8,14 +8,29 @@ variable "lb_subnet_ids" {
   type        = list(string)
 }
 
+variable "app" {
+  description = "The app name for the service, like datawatch"
+  type        = string
+}
+
 variable "instance" {
-  description = "Name of the environment instance."
+  description = "The stack instance name"
+  type        = string
+}
+
+variable "stack" {
+  description = "The stack name"
   type        = string
 }
 
 variable "name" {
-  description = "Name of this service instance."
+  description = "The name to use for the service, like staging-staging-datawatch"
   type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to put on the resources"
+  type        = map(string)
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
solr was not getting tags.  Also normalize the solr submodule's input variable names so they match the other services.