### PR TITLE
fix: revert "feat: use for_each instead of count for security group rulse

### DIFF
--- a/modules/rds/delete_in_the_next_major_version.tf
+++ b/modules/rds/delete_in_the_next_major_version.tf
@@ -1,71 +1,71 @@
 # This file will be deleted with the next major version release of this module
 
-resource "aws_security_group" "db" {
+resource "aws_security_group" "db_v2" {
   count  = var.create_security_groups ? 1 : 0
   vpc_id = var.vpc_id
-  name   = "${var.name}-db"
+  name   = "${var.name}-db-v2"
   tags = merge(var.tags, {
     Duty = "db"
     Name = "${var.name}-db"
   })
 }
 
-resource "aws_vpc_security_group_ingress_rule" "client_sg" {
+resource "aws_vpc_security_group_ingress_rule" "client_sg_v2" {
   count             = var.create_security_groups ? 1 : 0
-  security_group_id = aws_security_group.db[0].id
+  security_group_id = aws_security_group.db_v2[0].id
 
   from_port                    = 3306
   to_port                      = 3306
   ip_protocol                  = "TCP"
   description                  = "Allows MySQL port from client sg"
-  referenced_security_group_id = aws_security_group.db_clients[0].id
+  referenced_security_group_id = aws_security_group.db_clients_v2[0].id
 }
 
-resource "aws_vpc_security_group_ingress_rule" "other_sgs" {
-  count             = var.create_security_groups ? length(var.allowed_client_security_group_ids) : 0
-  security_group_id = aws_security_group.db[0].id
+resource "aws_vpc_security_group_ingress_rule" "other_sgs_v2" {
+  for_each          = var.create_security_groups ? toset(var.allowed_client_security_group_ids) : []
+  security_group_id = aws_security_group.db_v2[0].id
 
   from_port                    = 3306
   to_port                      = 3306
   ip_protocol                  = "TCP"
-  description                  = "Allows MySQL port from ${var.allowed_client_security_group_ids[count.index]}"
-  referenced_security_group_id = var.allowed_client_security_group_ids[count.index]
+  description                  = "Allows MySQL port from ${each.key}"
+  referenced_security_group_id = each.key
 }
 
-resource "aws_vpc_security_group_ingress_rule" "additional_cidrs" {
-  count             = var.create_security_groups ? length(var.additional_ingress_cidrs) : 0
-  security_group_id = aws_security_group.db[0].id
+resource "aws_vpc_security_group_ingress_rule" "additional_cidrs_v2" {
+  for_each          = var.create_security_groups ? toset(var.additional_ingress_cidrs) : []
+  security_group_id = aws_security_group.db_v2[0].id
 
   from_port   = 3306
   to_port     = 3306
   ip_protocol = "TCP"
-  description = "Allows MySQL port from ${var.additional_ingress_cidrs[count.index]}"
-  cidr_ipv4   = var.additional_ingress_cidrs[count.index]
+  description = "Allows MySQL port from ${each.key}"
+  cidr_ipv4   = each.key
 }
 
-resource "aws_security_group" "db_clients" {
+resource "aws_security_group" "db_clients_v2" {
   count  = var.create_security_groups ? 1 : 0
   vpc_id = var.vpc_id
-  name   = "${var.name}-db-clients"
+  name   = "${var.name}-db-clients-v2"
   tags = merge(var.tags, {
     Duty = "dbclients"
     Name = "${var.name}-db-clients"
   })
 }
 
-resource "aws_security_group" "db_replica" {
+resource "aws_security_group" "db_replica_v2" {
   count  = var.create_security_groups && var.create_replica ? 1 : 0
   vpc_id = var.vpc_id
-  name   = "${var.name}-db-replica"
+  name   = "${var.name}-db-replica-v2"
   tags = merge(var.tags, {
     Duty = "db"
     Name = "${var.name}-db-replica"
   })
 }
 
-resource "aws_vpc_security_group_ingress_rule" "replica_client_sg" {
+resource "aws_vpc_security_group_ingress_rule" "replica_client_sg_v2" {
   count             = var.create_security_groups && var.create_replica ? 1 : 0
-  security_group_id = aws_security_group.db_replica[0].id
+  security_group_id = aws_security_group.db_replica_v2[0].id
 
   from_port                    = 3306
   to_port                      = 3306
@@ -74,34 +74,34 @@ resource "aws_vpc_security_group_ingress_rule" "replica_client_sg" {
   referenced_security_group_id = aws_security_group.db_replica_clients[0].id
 }
 
-resource "aws_security_group" "db_replica_clients" {
+resource "aws_security_group" "db_replica_clients_v2" {
   count  = var.create_security_groups && var.create_replica ? 1 : 0
   vpc_id = var.vpc_id
-  name   = "${var.name}-db-replica-clients"
+  name   = "${var.name}-db-replica-clients-v2"
   tags = merge(var.tags, {
     Duty = "dbclients"
     Name = "${var.name}-db-replica-clients"
   })
 }
 
-resource "aws_vpc_security_group_ingress_rule" "replica_other_sgs" {
-  count             = var.create_security_groups && var.create_replica ? length(var.allowed_client_security_group_ids) : 0
-  security_group_id = aws_security_group.db_replica[0].id
+resource "aws_vpc_security_group_ingress_rule" "replica_other_sgs_v2" {
+  for_each          = var.create_security_groups && var.create_replica ? toset(var.allowed_client_security_group_ids) : []
+  security_group_id = aws_security_group.db_replica_v2[0].id
 
   from_port                    = 3306
   to_port                      = 3306
   ip_protocol                  = "TCP"
-  description                  = "Allows MySQL port from ${var.allowed_client_security_group_ids[count.index]}"
-  referenced_security_group_id = var.allowed_client_security_group_ids[count.index]
+  description                  = "Allows MySQL port from ${each.key}"
+  referenced_security_group_id = each.key
 }
 
-resource "aws_vpc_security_group_ingress_rule" "replica_additional_cidrs" {
-  count             = var.create_security_groups && var.create_replica ? length(var.additional_ingress_cidrs) : 0
-  security_group_id = aws_security_group.db_replica[0].id
+resource "aws_vpc_security_group_ingress_rule" "replica_additional_cidrs_v2" {
+  for_each          = var.create_security_groups && var.create_replica ? toset(var.additional_ingress_cidrs) : []
+  security_group_id = aws_security_group.db_replica_v2[0].id
 
   from_port   = 3306
   to_port     = 3306
   ip_protocol = "TCP"
-  description = "Allows MySQL port from ${var.additional_ingress_cidrs[count.index]}"
-  cidr_ipv4   = var.additional_ingress_cidrs[count.index]
+  description = "Allows MySQL port from ${each.key}"
+  cidr_ipv4   = each.key
 }

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -49,106 +49,106 @@ locals {
   ]
 }
 
-resource "aws_security_group" "db_v2" {
+resource "aws_security_group" "db" {
   count  = var.create_security_groups ? 1 : 0
   vpc_id = var.vpc_id
-  name   = "${var.name}-db-v2"
+  name   = "${var.name}-db"
   tags = merge(var.tags, {
     Duty = "db"
     Name = "${var.name}-db"
   })
 }
 
-resource "aws_vpc_security_group_ingress_rule" "client_sg_v2" {
+resource "aws_vpc_security_group_ingress_rule" "client_sg" {
   count             = var.create_security_groups ? 1 : 0
-  security_group_id = aws_security_group.db_v2[0].id
+  security_group_id = aws_security_group.db[0].id
 
   from_port                    = 3306
   to_port                      = 3306
   ip_protocol                  = "TCP"
   description                  = "Allows MySQL port from client sg"
-  referenced_security_group_id = aws_security_group.db_clients_v2[0].id
+  referenced_security_group_id = aws_security_group.db_clients[0].id
 }
 
-resource "aws_vpc_security_group_ingress_rule" "other_sgs_v2" {
-  for_each          = var.create_security_groups ? toset(var.allowed_client_security_group_ids) : []
-  security_group_id = aws_security_group.db_v2[0].id
+resource "aws_vpc_security_group_ingress_rule" "other_sgs" {
+  count             = var.create_security_groups ? length(var.allowed_client_security_group_ids) : 0
+  security_group_id = aws_security_group.db[0].id
 
   from_port                    = 3306
   to_port                      = 3306
   ip_protocol                  = "TCP"
-  description                  = "Allows MySQL port from ${each.key}"
-  referenced_security_group_id = each.key
+  description                  = "Allows MySQL port from ${var.allowed_client_security_group_ids[count.index]}"
+  referenced_security_group_id = var.allowed_client_security_group_ids[count.index]
 }
 
-resource "aws_vpc_security_group_ingress_rule" "additional_cidrs_v2" {
-  for_each          = var.create_security_groups ? toset(var.additional_ingress_cidrs) : []
-  security_group_id = aws_security_group.db_v2[0].id
+resource "aws_vpc_security_group_ingress_rule" "additional_cidrs" {
+  count             = var.create_security_groups ? length(var.additional_ingress_cidrs) : 0
+  security_group_id = aws_security_group.db[0].id
 
   from_port   = 3306
   to_port     = 3306
   ip_protocol = "TCP"
-  description = "Allows MySQL port from ${each.key}"
-  cidr_ipv4   = each.key
+  description = "Allows MySQL port from ${var.additional_ingress_cidrs[count.index]}"
+  cidr_ipv4   = var.additional_ingress_cidrs[count.index]
 }
 
-resource "aws_security_group" "db_clients_v2" {
+resource "aws_security_group" "db_clients" {
   count  = var.create_security_groups ? 1 : 0
   vpc_id = var.vpc_id
-  name   = "${var.name}-db-clients-v2"
+  name   = "${var.name}-db-clients"
   tags = merge(var.tags, {
     Duty = "dbclients"
     Name = "${var.name}-db-clients"
   })
 }
 
-resource "aws_security_group" "db_replica_v2" {
+resource "aws_security_group" "db_replica" {
   count  = var.create_security_groups && var.create_replica ? 1 : 0
   vpc_id = var.vpc_id
-  name   = "${var.name}-db-replica-v2"
+  name   = "${var.name}-db-replica"
   tags = merge(var.tags, {
     Duty = "db"
     Name = "${var.name}-db-replica"
   })
 }
 
-resource "aws_vpc_security_group_ingress_rule" "replica_client_sg_v2" {
+resource "aws_vpc_security_group_ingress_rule" "replica_client_sg" {
   count             = var.create_security_groups && var.create_replica ? 1 : 0
-  security_group_id = aws_security_group.db_replica_v2[0].id
+  security_group_id = aws_security_group.db_replica[0].id
 
   from_port                    = 3306
   to_port                      = 3306
   ip_protocol                  = "TCP"
   description                  = "Allows MySQL port from client sg"
-  referenced_security_group_id = aws_security_group.db_replica_clients_v2[0].id
+  referenced_security_group_id = aws_security_group.db_replica_clients[0].id
 }
 
-resource "aws_vpc_security_group_ingress_rule" "replica_other_sgs_v2" {
-  for_each          = var.create_security_groups && var.create_replica ? toset(var.allowed_client_security_group_ids) : []
-  security_group_id = aws_security_group.db_replica_v2[0].id
+resource "aws_vpc_security_group_ingress_rule" "replica_other_sgs" {
+  count             = var.create_security_groups && var.create_replica ? length(var.allowed_client_security_group_ids) : 0
+  security_group_id = aws_security_group.db_replica[0].id
 
   from_port                    = 3306
   to_port                      = 3306
   ip_protocol                  = "TCP"
-  description                  = "Allows MySQL port from ${each.key}"
-  referenced_security_group_id = each.key
+  description                  = "Allows MySQL port from ${var.allowed_client_security_group_ids[count.index]}"
+  referenced_security_group_id = var.allowed_client_security_group_ids[count.index]
 }
 
-resource "aws_vpc_security_group_ingress_rule" "replica_additional_cidrs_v2" {
-  for_each          = var.create_security_groups && var.create_replica ? toset(var.additional_ingress_cidrs) : []
-  security_group_id = aws_security_group.db_replica_v2[0].id
+resource "aws_vpc_security_group_ingress_rule" "replica_additional_cidrs" {
+  count             = var.create_security_groups && var.create_replica ? length(var.additional_ingress_cidrs) : 0
+  security_group_id = aws_security_group.db_replica[0].id
 
   from_port   = 3306
   to_port     = 3306
   ip_protocol = "TCP"
-  description = "Allows MySQL port from ${each.key}"
-  cidr_ipv4   = each.key
+  description = "Allows MySQL port from ${var.additional_ingress_cidrs[count.index]}"
+  cidr_ipv4   = var.additional_ingress_cidrs[count.index]
 }
 
-resource "aws_security_group" "db_replica_clients_v2" {
+resource "aws_security_group" "db_replica_clients" {
   count  = var.create_security_groups && var.create_replica ? 1 : 0
   vpc_id = var.vpc_id
-  name   = "${var.name}-db-replica-clients-v2"
+  name   = "${var.name}-db-replica-clients"
   tags = merge(var.tags, {
     Duty = "dbclients"
     Name = "${var.name}-db-replica-clients"
@@ -178,7 +178,7 @@ module "this" {
   create_db_subnet_group = false
   db_subnet_group_name   = var.db_subnet_group_name
   multi_az               = var.enable_multi_az
-  vpc_security_group_ids = var.create_security_groups ? concat([aws_security_group.db_v2[0].id], var.extra_security_group_ids) : var.extra_security_group_ids
+  vpc_security_group_ids = var.create_security_groups ? concat([aws_security_group.db[0].id], var.extra_security_group_ids) : var.extra_security_group_ids
 
   allocated_storage     = var.allocated_storage
   max_allocated_storage = var.max_allocated_storage
@@ -231,7 +231,7 @@ module "replica" {
   port                   = 3306
   create_db_subnet_group = false
   multi_az               = false
-  vpc_security_group_ids = var.create_security_groups ? concat([aws_security_group.db_replica_v2[0].id], var.extra_security_group_ids) : var.extra_security_group_ids
+  vpc_security_group_ids = var.create_security_groups ? concat([aws_security_group.db_replica[0].id], var.extra_security_group_ids) : var.extra_security_group_ids
 
   allocated_storage     = var.allocated_storage
   max_allocated_storage = var.max_allocated_storage

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -20,12 +20,12 @@ output "master_user_name" {
 
 output "client_security_group_id" {
   description = "Security group id for clients"
-  value       = var.create_security_groups ? aws_security_group.db_clients_v2[0].id : ""
+  value       = var.create_security_groups ? aws_security_group.db_clients[0].id : ""
 }
 
 output "replica_client_security_group_id" {
   description = "Security group ID for the replica"
-  value       = var.create_replica && var.create_security_groups ? aws_security_group.db_replica_v2[0].id : ""
+  value       = var.create_replica && var.create_security_groups ? aws_security_group.db_replica[0].id : ""
 }
 
 output "primary_dns_name" {


### PR DESCRIPTION
This reverts commit 4c73c3552dc922bbd97f0bca7724651235289a38.

for_each does not work when module is applied from scratch.

Fixes this error
> The "for_each" set includes values derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.