### PR TITLE
fix: calculate solr heap size based on container mem

### DIFF
--- a/modules/solr-single-instance/main.tf
+++ b/modules/solr-single-instance/main.tf
@@ -248,7 +248,6 @@ locals {
   solr_default_opts = [
     "-Dfile.encoding=UTF-8",
   ]
-  solr_default_heap_size = ceil(data.aws_ec2_instance_type.this.memory_size * 0.8)
   solr_tags = merge(var.tags, {
     app       = var.app
     component = "solr"


### PR DESCRIPTION
We want to account for the side car containers and not try to use too much mem.  Doing so drives up cpu util drastically