### PR TITLE
fix: pin solr CPU reservation for primary container

### DIFF
--- a/modules/solr-single-instance/main.tf
+++ b/modules/solr-single-instance/main.tf
@@ -262,6 +262,9 @@ locals {
 
 resource "aws_ecs_task_definition" "solr" {
   family = var.name
+  # While cpu is optional, pinning it allows our CPU graphs to read as 100% showing full utilization,
+  # vs without where util could be 300%, 700% etc
+  cpu = local.ec2_cpu_units
   # Setting mem here is technically optional, but I was able to eek out another 256 of container mem by setting this.
   memory                = local.ec2_mem_usable
   container_definitions = jsonencode(local.container_definitions)


### PR DESCRIPTION
With this floating, the CPU charts look very strange.  This is an experiement to normalize the CPU charts so it looks like all of the other ECS tasks where 100% full utilization.

Right now due to the floating CPU reservation, the CPU util observed can be 300%, 700% etc.

Imaging showing .5 as the ECS task's CPU reservation
![image](https://github.com/user-attachments/assets/1195bcd5-1bc7-4163-8bae-b7c95152e0ca)
