### PR TITLE
fix: use a flat value for OS overhead for solr mem calculation

### DIFF
--- a/modules/solr-single-instance/main.tf
+++ b/modules/solr-single-instance/main.tf
@@ -261,7 +261,9 @@ locals {
 }
 
 resource "aws_ecs_task_definition" "solr" {
-  family                = var.name
+  family = var.name
+  # Setting mem here is technically optional, but I was able to eek out another 256 of container mem by setting this.
+  memory                = local.ec2_mem_usable
   container_definitions = jsonencode(local.container_definitions)
   network_mode          = "awsvpc"
   requires_compatibilities = [


### PR DESCRIPTION
90% of OS is a floating value based on instance size, but really the OS overhead of the kernel + ECS things should be a fixed value.

256 is likely the right number, but 512 is a safe starting place for solr since we need this layer to be as stable as possible since it is the database for the lineageplus application.

Closes SRE-4444