### PR TITLE
feat: add a dedicated general purpose internal load balancer

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -30,6 +30,8 @@ locals {
   elasticache_subnet_group_name   = local.create_vpc ? module.vpc[0].elasticache_subnet_group_name : var.byovpc_redis_subnet_group_name
   rabbitmq_subnet_group_ids       = local.create_vpc ? module.vpc[0].elasticache_subnets : var.byovpc_rabbitmq_subnet_ids
 
+  internal_alb_ingress_cidrs = concat([var.vpc_cidr_block], var.internal_additional_ingress_cidrs)
+
   # Temporal Task Queues
   catalog_indexing_temporal_queues = ["indexing.v1"]
   root_cause_temporal_queues       = ["issue-root-cause"]

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -88,6 +88,12 @@ variable "internal_additional_ingress_cidrs" {
   default     = []
 }
 
+variable "internal_extra_security_group_ids" {
+  description = "Additional security group ids to attach to internal load balancers"
+  type        = list(string)
+  default     = []
+}
+
 #======================================================
 # VPC
 #======================================================


### PR DESCRIPTION
No actual services are being migrated through the new ALB in this PR.

This is the first step to consolidating the internal load balancers into 1 and using path based routing instead of load balancer per service.

This is a cost savings step as each LB is ~$23/mo and it adds up with so many internal services.

Future PRs will migrate the services over and remove the dedicated per-service ALBs.