### PR TITLE
fix: remove publish bundle step from CI deploy

### DIFF
--- a/.github/workflows/test_and_publish.yaml
+++ b/.github/workflows/test_and_publish.yaml
@@ -178,14 +178,3 @@ jobs:
         run: |
           git push -d origin release-from-${{ github.sha }} || echo "failed to delete branch"
           git push -d origin ${{ steps.changelog.outputs.tag }} || echo "failed to delete tag"
-
-
-  publish_bundle:
-    name: Publish bundle
-    needs: [publish]
-    if: ${{ needs.publish.outputs.skipped == 'false' }}
-    uses: ./.github/workflows/publish_bundle_s3.yaml
-    secrets: inherit
-    with:
-      ref: main
-      bundlename: ${{ needs.publish.outputs.tag }}


### PR DESCRIPTION
We no longer publish our source to S3 for consumption.  There was a customer that needed all dependencies pre-packaged (ie could not download terraform modules/deps from public net), but they no longer need this.

Disable this to avoid wasted work