### PR TITLE
feat: add flag to control TEMPORAL_LARGE_PAYLOAD_ENABLED env var

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2251,6 +2251,7 @@ locals {
     TEMPORAL_TARGET                            = "${local.temporal_dns_name}:${local.temporal_lb_port}"
     TEMPORAL_NAMESPACE                         = var.temporal_namespace
     TEMPORAL_SSL_HOSTNAME_VERIFICATION_ENABLED = var.temporal_use_default_certificates ? "false" : "true"
+    TEMPORAL_LARGE_PAYLOAD_ENABLED             = var.datawatch_temporal_large_payload_enabled
 
     MAILER_HOST         = local.byomailserver_smtp_host
     MAILER_PORT         = local.byomailserver_smtp_port

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2006,6 +2006,12 @@ variable "datawatch_max_request_size" {
   type        = string
 }
 
+variable "datawatch_temporal_large_payload_enabled" {
+  description = "Controls if datawatch common services have the temporal large payload converter enabled.  It is not common to deviate from the default setting."
+  type        = bool
+  default     = false
+}
+
 #======================================================
 # Application Variables - Backfillwork
 #======================================================


### PR DESCRIPTION
This will enable/disable the large pyalod converter for java based services.

For customers, basically don't set this, it's a feature flag for rolling out a new feature.  We will be updating the defaults here when the feature is stable and you will get it naturally then.