### PR TITLE
feat!: migrate off of inline security group rules part 2/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ terraform version and application version.
 
 ## Upgrading
 
+### Upgrading to 19.0.0
+
+Be sure to apply 18.0.0 first, or the previously inline security group
+rules that were removed will be left dangling and will cause conflicts
+down the road.
+
 ### Upgrading to 18.0.0
 
 18.0.0 is the first step in a 2 part series to migrate from inline security

--- a/modules/simpleservice/main.tf
+++ b/modules/simpleservice/main.tf
@@ -29,8 +29,6 @@ resource "aws_security_group" "lb" {
   tags = merge(var.tags, {
     Name = "${var.name}-lb"
   })
-  ingress = []
-  egress  = []
 }
 
 resource "aws_vpc_security_group_ingress_rule" "lb_http" {
@@ -209,9 +207,6 @@ resource "aws_security_group" "this" {
   tags = merge(var.tags, {
     Name = var.name
   })
-
-  ingress = []
-  egress  = []
 }
 
 resource "aws_vpc_security_group_ingress_rule" "this_lb_to_service" {


### PR DESCRIPTION
BREAKING CHANGE: Part one should only be applied 1x.  Then upgrade
to part 2 and the plan will be idempotent again.

Closes SRE-4838