### PR TITLE
fix: pin sha for all github actions and fix publish GH action

### DIFF
--- a/.github/workflows/hook_update_image_tag.yaml
+++ b/.github/workflows/hook_update_image_tag.yaml
@@ -22,7 +22,8 @@ jobs:
   update_tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
       - name: set up branch
@@ -36,7 +37,8 @@ jobs:
           git status
           git diff | cat
           git diff HEAD~1 | cat
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      # v5.2.0
+      - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403
         with:
           create_branch: false
           branch: "update-image-tag-${{ inputs.tag }}"

--- a/.github/workflows/publish_bundle_s3.yaml
+++ b/.github/workflows/publish_bundle_s3.yaml
@@ -42,12 +42,14 @@ jobs:
           echo "ref=${ref}" >> $GITHUB_OUTPUT
           echo "tarname=${tarname}"
           echo "tarname=${tarname}" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v4
+      # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ steps.determine-ref.outputs.ref }}
           path: terraform-modules
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@v3.0.0
+        # v3.1.2
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
         with:
           terraform_version: 1.7.5
           # https://github.com/hashicorp/setup-terraform/issues/373
@@ -62,7 +64,8 @@ jobs:
           ls -ahl
       - name: Configure AWS credentials
         if: "${{ github.event_name != 'pull_request' }}"
-        uses: aws-actions/configure-aws-credentials@v4.0.1
+        # v4.1.0
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test_and_publish.yaml
+++ b/.github/workflows/test_and_publish.yaml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - modules/**/*
+      - .github/workflows/test_and_publish.yaml
 
 concurrency:
   group: ${{ github.workflow }}
@@ -58,35 +59,16 @@ jobs:
     - name: Terraform lint check
       run: terraform -chdir=${{ matrix.directory }} fmt -check
 
-  changelog:
-    needs:
-      - validate
-    runs-on: ubuntu-latest
-    outputs:
-      clean_changelog: ${{ steps.changelog.outputs.clean_changelog }}
-      skipped: ${{ steps.changelog.outputs.skipped }}
-      tag: ${{ steps.changelog.outputs.tag }}
-    steps:
-      - name: build changelog
-        id: changelog
-        uses: TriPSs/conventional-changelog-action@c6e8c216679c1c923820011e544cbe0e813b8057
-        with:
-          git-branch: "release-from-${{ github.sha }}"
-          create-summary: true
-          skip-git-pull: true
-          release-count: 0
-          input-file: CHANGELOG.md
-
   publish:
     name: Publish
     runs-on: ubuntu-latest
     needs:
-      - changelog
+      - validate
     timeout-minutes: 5
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
     outputs:
-      skipped: ${{ needs.changelog.outputs.skipped }}
-      tag: ${{ needs.changelog.outputs.tag }}
+      skipped: ${{ steps.changelog.outputs.skipped }}
+      tag: ${{ steps.changelog.outputs.tag }}
     steps:
       # v4.2.2
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -101,10 +83,18 @@ jobs:
         run: |
           git branch "release-from-${{ github.sha }}" "${{ github.sha }}"
           git checkout "release-from-${{ github.sha }}"
-
+      - name: build changelog
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@c6e8c216679c1c923820011e544cbe0e813b8057
+        with:
+          git-branch: "release-from-${{ github.sha }}"
+          create-summary: true
+          skip-git-pull: true
+          release-count: 0
+          input-file: CHANGELOG.md
       - name: replace tf release version in scripts
-        if: ${{ needs.changelog.outputs.skipped == 'false' }}
-        run: ./scripts/replace-terraform-version.sh "${{ needs.changelog.outputs.tag }}"
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        run: ./scripts/replace-terraform-version.sh "${{ steps.changelog.outputs.tag }}"
       - name: inspect git status
         run: |
           git status
@@ -112,62 +102,61 @@ jobs:
           git diff HEAD~1 | cat
       # v5.2.0
       - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403
-        if: ${{ needs.changelog.outputs.skipped == 'false' }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
         with:
           create_branch: false
           branch: "release-from-${{ github.sha }}"
-          commit_message: "chore(release): update example docs to use new version ${{ needs.changelog.outputs.tag }}"
+          commit_message: "chore(release): update example docs to use new version ${{ steps.changelog.outputs.tag }}"
           file_pattern: examples/**/*
           skip_fetch: true
       - name: create PR with release
-        if: ${{ needs.changelog.outputs.skipped == 'false' }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
         id: create-pr
-        run: gh pr create --base main --head release-from-${{ github.sha }} --title "Add release notes for ${{ needs.changelog.outputs.tag }}" --body "Created by action ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: gh pr create --base main --head release-from-${{ github.sha }} --title "Add release notes for ${{ steps.changelog.outputs.tag }}" --body "Created by action ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: approve pr
-        if: ${{ needs.changelog.outputs.skipped == 'false' }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: |
           gh pr review "release-from-${{ github.sha }}" --approve
         env:
           GH_TOKEN: ${{ secrets.BIGEYE_SRE_BOT_GH_PAT }}
       - name: merge PR with release info
-        if: ${{ needs.changelog.outputs.skipped == 'false' }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
         id: merge-pr
         run: |
-          gh pr merge "release-from-${{ github.sha }}" --admin --merge --delete-branch --subject "chore: merge release docs for ${{ needs.changelog.outputs.tag }}"
+          gh pr merge "release-from-${{ github.sha }}" --admin --merge --delete-branch --subject "chore: merge release docs for ${{ steps.changelog.outputs.tag }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: create release with last commit
-        if: ${{ needs.changelog.outputs.skipped == 'false' }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
         # v1.16.0
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.changelog.outputs.tag }}
-          name: ${{ needs.changelog.outputs.tag }}
-          body: ${{ needs.changelog.outputs.clean_changelog }}
+          tag: ${{ steps.changelog.outputs.tag }}
+          name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
       - name: notify SDP
-        if: ${{ needs.changelog.outputs.skipped == 'false' }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: |
-          gh workflow run "TF Bump Module Version" -R "bigeyedata/semantic-data-platform" --field "previousVersion=${{ steps.prevversion.outputs.PREVIOUS_VERSION }}" --field "version=${{ needs.changelog.outputs.tag }}"
+          gh workflow run "TF Bump Module Version" -R "bigeyedata/semantic-data-platform" --field "previousVersion=${{ steps.prevversion.outputs.PREVIOUS_VERSION }}" --field "version=${{ steps.changelog.outputs.tag }}"
         env:
           GITHUB_TOKEN: ${{ secrets.BIGEYE_SRE_BOT_GH_PAT }}
       - name: failure - delete branch and tag
-        if: ${{ failure() && needs.changelog.outputs.skipped == 'false' }}
+        if: ${{ failure() && steps.changelog.outputs.skipped == 'false' }}
         run: |
           git push -d origin release-from-${{ github.sha }} || echo "failed to delete branch"
-          git push -d origin ${{ needs.changelog.outputs.tag }} || echo "failed to delete tag"
+          git push -d origin ${{ steps.changelog.outputs.tag }} || echo "failed to delete tag"
 
   notify-on-success:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
-      - changelog
       - publish
     steps:
       - name: notify slack
-        if: ${{ needs.changelog.outputs.skipped == 'false' }}
+        if: ${{ needs.publish.outputs.skipped == 'false' }}
         # v2.0.0
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d
         env:
@@ -181,7 +170,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":shipitparrot: terraform-modules successfully published version ${{ needs.changelog.outputs.tag }}. [<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.changelog.outputs.tag }}|Release>]"
+                    "text": ":shipitparrot: terraform-modules successfully published version ${{ needs.publish.outputs.tag }}. [<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.publish.outputs.tag }}|Release>]"
                   }
                 }
               ]
@@ -191,10 +180,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
-      - changelog
       - publish
     if: |
-      always() && (needs.publish.result != 'success')
+      always() && needs.publish.result != 'success' && needs.publish.result != 'skipped'
     steps:
       - name: Notify on fail
         # v2.0.0
@@ -210,7 +198,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":sadparrot: terraform-modules publish version ${{ needs.changelog.outputs.tag }} failed. [<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| GH Action>]"
+                    "text": ":sadparrot: terraform-modules publish version ${{ needs.publish.outputs.tag }} failed. [<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| GH Action>]"
                   }
                 }
               ]

--- a/.github/workflows/test_and_publish.yaml
+++ b/.github/workflows/test_and_publish.yaml
@@ -21,7 +21,8 @@ jobs:
     outputs:
       dir: ${{ steps.setdirs.outputs.dir }}
     steps:
-      - uses: actions/checkout@v4
+      # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - id: setdirs
         run: |
           # shellcheck disable=SC2012
@@ -37,12 +38,14 @@ jobs:
         directory: ${{ fromJson(needs.directories.outputs.dir) }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      # v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Get git status
       run: git status
-    
+
     - name: Setup terraform
-      uses: hashicorp/setup-terraform@v3
+      # v3.1.2
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
       with:
         terraform_version: "1.5.7"
 
@@ -66,7 +69,7 @@ jobs:
     steps:
       - name: build changelog
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v5
+        uses: TriPSs/conventional-changelog-action@c6e8c216679c1c923820011e544cbe0e813b8057
         with:
           git-branch: "release-from-${{ github.sha }}"
           create-summary: true
@@ -85,7 +88,8 @@ jobs:
       skipped: ${{ needs.changelog.outputs.skipped }}
       tag: ${{ needs.changelog.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
       - name: fetch current version
@@ -106,7 +110,8 @@ jobs:
           git status
           git diff | cat
           git diff HEAD~1 | cat
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      # v5.2.0
+      - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403
         if: ${{ needs.changelog.outputs.skipped == 'false' }}
         with:
           create_branch: false
@@ -135,7 +140,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: create release with last commit
         if: ${{ needs.changelog.outputs.skipped == 'false' }}
-        uses: ncipollo/release-action@v1
+        # v1.16.0
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.changelog.outputs.tag }}
@@ -162,7 +168,8 @@ jobs:
     steps:
       - name: notify slack
         if: ${{ needs.changelog.outputs.skipped == 'false' }}
-        uses: slackapi/slack-github-action@v1.25.0
+        # v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
         with:
@@ -190,7 +197,8 @@ jobs:
       always() && (needs.publish.result != 'success')
     steps:
       - name: Notify on fail
-        uses: slackapi/slack-github-action@v1.25.0
+        # v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
         with:

--- a/.github/workflows/test_commitlint.yaml
+++ b/.github/workflows/test_commitlint.yaml
@@ -7,12 +7,14 @@ jobs:
     name: Test commit format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.base.sha }}
       - name: Setup Node
-        uses: actions/setup-node@v4.0.2
+        # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 18
       - name: Install deps

--- a/.github/workflows/validate_docs.yaml
+++ b/.github/workflows/validate_docs.yaml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4.1.1
+      # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: "Markdown lint codebase"
         uses: docker://avtodev/markdown-lint:v1
         with:

--- a/.github/workflows/validate_github_actions_workflows.yaml
+++ b/.github/workflows/validate_github_actions_workflows.yaml
@@ -11,9 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4.1.1
+      # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: "Actionlint GH Actions workflows"
-        uses: reviewdog/action-actionlint@v1.34.0
+        # v1.65.2
+        uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281
         with:
           filter_mode: file
           actionlint_flags: "--ignore SC2086 --ignore SC2046"

--- a/.github/workflows/validate_shell_script_syntax.yaml
+++ b/.github/workflows/validate_shell_script_syntax.yaml
@@ -15,11 +15,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: "Get changed files"
         id: changed-files
-        uses: tj-actions/changed-files@v42.0.2
+        # v46.0.5
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
         with:
           files: |
             **/*.sh
@@ -43,10 +45,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Differential ShellCheck
-        uses: sudo-bot/action-shellcheck@latest
+        # latest
+        uses: sudo-bot/action-shellcheck@547e00d83d81f6aadc9f7c46edad946299356252
         with:
           # https://github.com/koalaman/shellcheck#how-to-use
           # add more files as a space separated value below.  Wildcards are okay


### PR DESCRIPTION
commit 7e956b4d6788688f1206224b7acfe2fec4818cd9 (HEAD -> david/sre-4859-terraform-modules-publish-version-failed-in-gh-action, origin/david/sre-4859-terraform-modules-publish-version-failed-in-gh-action)
Author: David Nguyen <david@bigeye.com>
Date:   Thu Apr 24 15:09:32 2025 -0700

    fix: fix busted publish GH action

    This action isn't working after https://github.com/bigeyedata/terraform-modules/pull/485/files

    The changelog needs git checkout.  Overall the premise of running
    the changelog in its own step was completely unncessary, so I
    put it back to fix the error and have used the output from within
    the publish step to drive the notification jobs instead.

commit b50fc511803b7c76976a174eb9575544ecdfc972
Author: David Nguyen <david@bigeye.com>
Date:   Thu Apr 24 14:53:29 2025 -0700

    fix: pin sha for all github actions

    The test and publish action is failing, might as well handle this
    now since the actions all have to be tested anyways.

    Pinning the sha is a security enhancement over using tagged versions
    as the tags are not immutable and can be retagged onto different
    commits.  Most deterministic is using the SHA (this is GH's
    recommendation as well)