### PR TITLE
feat: add env var to control routing of Lineage API requests

### DIFF
--- a/modules/bigeye/deprecated.tf
+++ b/modules/bigeye/deprecated.tf
@@ -9,3 +9,9 @@ variable "install_individual_internal_lbs" {
   type        = bool
   default     = true
 }
+
+variable "haproxy_lineageapi_enabled" {
+  description = "This is a feature flag to allow a controlled rollforward/rollback for routing lineage API calls to a dedicated lineageapi service.  By default this routes all backend requests through haproxy to the datawatch service (ie no change in behavior)"
+  type        = bool
+  default     = false
+}

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1047,12 +1047,6 @@ module "haproxy" {
       INSTANCE         = var.instance
       DW_HOST          = module.datawatch.dns_name
       DW_PORT          = "443"
-      SCHEDULER_HOST   = module.scheduler.dns_name
-      SCHEDULER_PORT   = "443"
-      TORETTO_HOST     = module.toretto.dns_name
-      TORETTO_PORT     = "443"
-      MONOCLE_HOST     = module.monocle.dns_name
-      MONOCLE_PORT     = "443"
       WEB_HOST         = module.web.dns_name
       WEB_PORT         = "443"
       REDIRECT_ADDRESS = "https://${local.vanity_dns_name}"

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1058,6 +1058,8 @@ module "haproxy" {
       REDIRECT_ADDRESS = "https://${local.vanity_dns_name}"
       PORT             = var.haproxy_port
       HAPROXY_PORT     = var.haproxy_port
+      LINEAGEAPI_HOST  = var.haproxy_lineageapi_enabled ? module.lineageapi.dns_name : module.datawatch.dns_name
+      LINEAGEAPI_PORT  = "443"
     },
     var.haproxy_additional_environment_vars,
   )


### PR DESCRIPTION
commit fe5ac2eb4a5d502780061bbe269a13f96734d30a (HEAD -> david/sre-4836-add-internal-lb-route-for-haproxy, origin/david/sre-4836-add-internal-lb-route-for-haproxy)
Author: David Nguyen <david@bigeye.com>
Date:   Mon Apr 28 17:08:48 2025 -0700

    chore: remove unused haproxy env vars

    These are old env vars that are no longer in use.

commit 4f872988cfca386786d7a246fb561f08e6dbaf46
Author: David Nguyen <david@bigeye.com>
Date:   Mon Apr 28 17:31:54 2025 -0700

    feat: add env var to control routing of Lineage API requests

    This is allows migrating lineage API calls to the dedicated lineageapi
    service via feature flag so it can be controlled differently on
    various installs.