### PR TITLE
feat: increase solr os ebs volume size and fix ebs tags

### DIFF
--- a/modules/solr-single-instance/main.tf
+++ b/modules/solr-single-instance/main.tf
@@ -59,6 +59,22 @@ resource "aws_launch_template" "solr" {
   metadata_options {
     http_tokens = "required"
   }
+
+  ebs_optimized = true
+  block_device_mappings {
+    ebs {
+      encrypted   = "true"
+      volume_size = var.ebs_volume_size_os
+    }
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+
+    tags = merge(local.solr_tags, {
+      Name = "${var.name}-os"
+    })
+  }
 }
 
 resource "aws_autoscaling_group" "solr" {

--- a/modules/solr-single-instance/variables.tf
+++ b/modules/solr-single-instance/variables.tf
@@ -57,10 +57,16 @@ variable "availability_zone" {
   type        = string
 }
 
+variable "ebs_volume_size_os" {
+  type    = string
+  default = 40
+}
+
 variable "ebs_volume_size" {
   type    = string
   default = 100
 }
+
 variable "ebs_volume_iops" {
   description = "Set iops to the value supported by your instance type. https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html"
   type        = number


### PR DESCRIPTION
The OS root EBS volume can get uncomfortably full 
at 30GB because solr logs are quite high volume.

We are also missing tags on the OS EBS volume