### PR TITLE
feat: add dedicated LB for external calls into Bigeye - part 1

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -30,6 +30,10 @@ locals {
   elasticache_subnet_group_name   = local.create_vpc ? module.vpc[0].elasticache_subnet_group_name : var.byovpc_redis_subnet_group_name
   rabbitmq_subnet_group_ids       = local.create_vpc ? module.vpc[0].elasticache_subnets : var.byovpc_rabbitmq_subnet_ids
 
+  external_alb_security_group_ids = concat(
+    var.create_security_groups ? [aws_security_group.external_alb[0].id] : [],
+    var.haproxy_extra_security_group_ids,
+  )
   internal_alb_ingress_cidrs = concat([var.vpc_cidr_block], var.internal_additional_ingress_cidrs)
   internal_alb_security_group_ids = concat(
     var.create_security_groups ? [aws_security_group.internal_alb[0].id] : [],


### PR DESCRIPTION
This will mirror the pattern used for the internal LB which is a single LB with path based routing instead of LB per service.

Overall this is a cost savings architecture improvement and does not improve performance/scalability outside of being more thrifty with internal IPs that each LB uses.