### PR TITLE
feat: allow setting solr OS root volume EBS volume size

### DIFF
--- a/modules/bigeye/lineageplus.tf
+++ b/modules/bigeye/lineageplus.tf
@@ -47,6 +47,7 @@ module "lineageplus_solr" {
   ebs_volume_size       = var.lineageplus_solr_ebs_volume_size
   ebs_volume_iops       = var.lineageplus_solr_ebs_volume_iops
   ebs_volume_throughput = var.lineageplus_solr_ebs_volume_throughput
+  ebs_volume_size_os    = var.lineageplus_solr_ebs_volume_size_os
   execution_role_arn    = local.ecs_role_arn
 
   # Datadog

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2697,6 +2697,12 @@ variable "lineageplus_solr_ebs_volume_throughput" {
   default     = 125
 }
 
+variable "lineageplus_solr_ebs_volume_size_os" {
+  description = "Size of root volume EBS volume attached to EC2 container instance running solr, in GB"
+  type        = number
+  default     = 40
+}
+
 variable "lineageplus_solr_cnames" {
   description = "CNAME Route53 records that will point to the main service DNS name."
   type        = list(string)


### PR DESCRIPTION
Only the solr data volume is configurable externally right now, plumb through the OS volume size as well.