### PR TITLE
fix: update MC username

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2020,7 +2020,7 @@ variable "datawatch_temporal_large_payload_enabled" {
 variable "datawatch_lineageplus_user_name" {
   description = "User name that is used by datawatch to make API calls to LineagePlus"
   type        = string
-  default     = "administrator"
+  default     = "1ap7Hf6VbvnrNYBIhH9K6A=="
 }
 
 variable "datawatch_lineageplus_password_secret_arn" {


### PR DESCRIPTION
MetaCenter has an encryption scheme that means we have to use the encrypted version rather than the normal version. There is no feasible way to get the encrypted version from the normal version right now, except manually to replace it as we are doing here.

In the future, we hope to update MetaCenter to accept the decrypted version of the username from Datawatch, but right now we can't.