### PR TITLE
feat: allow setting monocle worker count

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1388,7 +1388,7 @@ module "monocle" {
       DEPLOY_TYPE                = "AWS"
       QUEUE_CONNECTION_HEARTBEAT = "1000"
       BACKLOG                    = "512"
-      WORKERS                    = "2"
+      WORKERS                    = var.monocle_worker_count == 0 ? var.monocle_cpu * 2 / 1024 : 2
       TIMEOUT                    = "900"
       DATAWATCH_ADDRESS          = "https://${module.internalapi.dns_name}"
     },

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -588,6 +588,11 @@ variable "monocle_cpu" {
   description = "Amount of CPU to allocate"
   type        = number
   default     = 1024
+
+  validation {
+    condition     = var.monocle_cpu > 1024
+    error_message = "cpu should be a multiple of 1024 (ie 2 * 1024 for 2 cpus)"
+  }
 }
 
 variable "monocle_memory" {
@@ -655,6 +660,12 @@ variable "monocle_autoscaling_config" {
     condition     = contains(["none", "cpu_utilization", "request_count_per_target"], var.monocle_autoscaling_config.type)
     error_message = "Must be one of: none, cpu_utilization, request_count_per_target"
   }
+}
+
+variable "monocle_worker_count" {
+  description = "set the number of workers per monocle instance.  This is basically a max parallelism number and will affect /health as well.  Default (or setting to 0) is 2 * cpu count."
+  type        = number
+  default     = 0
 }
 
 #======================================================


### PR DESCRIPTION
This service can starve under higher volumes of requests.  More workers will allow the tasks to still service /health checks while serving more API calls concurrently.

Since gunicorn is singlethreaded, scaling the number based on CPU count will generally make sense so the default is being set now based on the number of CPU's instead of just 2.