### PR TITLE
fix: change monocle default autoscaling algo to cpu scaling

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -647,9 +647,9 @@ variable "monocle_autoscaling_config" {
   })
   default = {
     min_capacity       = 2
-    max_capacity       = 10
-    type               = "request_count_per_target"
-    target_utilization = 15
+    max_capacity       = 15
+    type               = "cpu_utilization"
+    target_utilization = 30
   }
   validation {
     condition     = contains(["none", "cpu_utilization", "request_count_per_target"], var.monocle_autoscaling_config.type)


### PR DESCRIPTION
CPU scaling is much more stable and efficient than request per target.

Also different sized installations with more history or other factors for generating thresholds tend to have variable run times and cpu load on API calls to monocle which also lends it self better to cpu auto scaling.

30% is chosen as the scaling target and is generally a safe number striking a balance between $ and response times when large batches comes in.