### PR TITLE
feat: change default for lineageplus solr log level to warn

### DIFF
--- a/modules/bigeye/lineageplus.tf
+++ b/modules/bigeye/lineageplus.tf
@@ -44,6 +44,7 @@ module "lineageplus_solr" {
   solr_jmx_port         = var.lineageplus_solr_jmx_port
   desired_count         = var.lineageplus_solr_desired_count
   solr_heap_size        = var.lineageplus_solr_heap_size
+  solr_log_level        = var.lineageplus_solr_log_level
   ebs_volume_size       = var.lineageplus_solr_ebs_volume_size
   ebs_volume_iops       = var.lineageplus_solr_ebs_volume_iops
   ebs_volume_throughput = var.lineageplus_solr_ebs_volume_throughput

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2747,6 +2747,17 @@ variable "lineageplus_solr_refresh_instance_on_launch_template_change" {
   type        = bool
   default     = false
 }
+
+variable "lineageplus_solr_log_level" {
+  description = "Log level for solr.  Controls the SOLR_LOG_LEVEL env var"
+  type        = string
+  default     = "WARN"
+  validation {
+    condition     = contains(["INFO", "WARN", "ERROR"], var.lineageplus_solr_log_level)
+    error_message = "solr_log_level must be one of: INFO, WARN, ERROR"
+  }
+}
+
 #======================================================
 # Cloudfront Variables
 #======================================================

--- a/modules/solr-single-instance/containers.tf
+++ b/modules/solr-single-instance/containers.tf
@@ -28,6 +28,7 @@ locals {
       SOLR_HEAP      = "${local.solr_heap_size}M"
       SOLR_PORT      = tostring(var.solr_traffic_port)
       SOLR_OPTS      = join(" ", concat(local.solr_default_opts, var.solr_opts))
+      SOLR_LOG_LEVEL = var.solr_log_level
   }) : { Name = k, Value = v }]
   container_environment_secrets = [for k, v in merge(local.datadog_service_secret_arns, var.secret_arns) : { Name = k, ValueFrom = v }]
 

--- a/modules/solr-single-instance/variables.tf
+++ b/modules/solr-single-instance/variables.tf
@@ -214,6 +214,16 @@ variable "environment_variables" {
   default     = {}
 }
 
+variable "solr_log_level" {
+  description = "Log level for solr.  Controls the SOLR_LOG_LEVEL env var"
+  type        = string
+  default     = "WARN"
+  validation {
+    condition     = contains(["INFO", "WARN", "ERROR"], var.solr_log_level)
+    error_message = "solr_log_level must be one of: INFO, WARN, ERROR"
+  }
+}
+
 #======================================================
 # Datadog agent settings
 #======================================================


### PR DESCRIPTION
This also allows setting the value.  These logs tend to be low value and high volume.  Allow setting this and change the default to be less verbose