### PR TITLE
fix: fix missing launch template ebs device name

### DIFF
--- a/modules/solr-single-instance/main.tf
+++ b/modules/solr-single-instance/main.tf
@@ -62,6 +62,7 @@ resource "aws_launch_template" "solr" {
 
   ebs_optimized = true
   block_device_mappings {
+    device_name = "/dev/xvda"
     ebs {
       encrypted   = "true"
       volume_size = var.ebs_volume_size_os


### PR DESCRIPTION
This is a bug introduced in https://github.com/bigeyedata/terraform-modules/pull/509

Without this, the autoscaling group fails to refresh and leaves solr in a down state.