### PR TITLE
feat: allow enabling alb anomaly mitigation

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -801,6 +801,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "models" {
     expiration {
       days = 45
     }
+    filter {}
   }
 }
 
@@ -833,6 +834,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "large_payload" {
     expiration {
       days = 7
     }
+    filter {}
   }
 }
 
@@ -987,18 +989,19 @@ module "haproxy" {
   fargate_version               = var.fargate_version
 
   # Load balancer
-  healthcheck_path                 = "/haproxy-health"
-  healthcheck_interval             = 15
-  healthcheck_timeout              = 5
-  healthcheck_unhealthy_threshold  = 3
-  ssl_policy                       = var.alb_ssl_policy
-  acm_certificate_arn              = local.acm_certificate_arn
-  lb_idle_timeout                  = var.lb_timeout
-  lb_subnet_ids                    = var.internet_facing ? local.public_alb_subnet_ids : local.internal_service_alb_subnet_ids
-  lb_additional_security_group_ids = concat(var.haproxy_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
-  lb_additional_ingress_cidrs      = var.additional_ingress_cidrs
-  lb_stickiness_enabled            = true
-  lb_deregistration_delay          = 900
+  healthcheck_path                  = "/haproxy-health"
+  healthcheck_interval              = 15
+  healthcheck_timeout               = 5
+  healthcheck_unhealthy_threshold   = 3
+  ssl_policy                        = var.alb_ssl_policy
+  acm_certificate_arn               = local.acm_certificate_arn
+  lb_idle_timeout                   = var.lb_timeout
+  lb_subnet_ids                     = var.internet_facing ? local.public_alb_subnet_ids : local.internal_service_alb_subnet_ids
+  lb_additional_security_group_ids  = concat(var.haproxy_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
+  lb_additional_ingress_cidrs       = var.additional_ingress_cidrs
+  lb_stickiness_enabled             = true
+  lb_deregistration_delay           = 900
+  load_balancing_anomaly_mitigation = false
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -1104,6 +1107,7 @@ module "web" {
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
   lb_stickiness_enabled                  = true
   lb_deregistration_delay                = 120
+  load_balancing_anomaly_mitigation      = false
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -1342,6 +1346,7 @@ module "monocle" {
   lb_additional_security_group_ids       = concat(var.monocle_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
   lb_deregistration_delay                = 300
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -1506,6 +1511,7 @@ module "toretto" {
   lb_subnet_ids                          = local.internal_service_alb_subnet_ids
   lb_additional_security_group_ids       = concat(var.toretto_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -1690,6 +1696,7 @@ module "scheduler" {
   lb_subnet_ids                          = local.internal_service_alb_subnet_ids
   lb_additional_security_group_ids       = concat(var.scheduler_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -2318,6 +2325,7 @@ module "datawatch" {
   lb_additional_security_group_ids       = concat(var.datawatch_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
   lb_deregistration_delay                = 900
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -2405,6 +2413,7 @@ module "datawork" {
   lb_subnet_ids                          = local.internal_service_alb_subnet_ids
   lb_additional_security_group_ids       = concat(var.datawork_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -2521,6 +2530,7 @@ module "backfillwork" {
   lb_subnet_ids                          = local.internal_service_alb_subnet_ids
   lb_additional_security_group_ids       = concat(var.backfillwork_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -2612,6 +2622,7 @@ module "indexwork" {
   lb_subnet_ids                          = local.internal_service_alb_subnet_ids
   lb_additional_security_group_ids       = concat(var.indexwork_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -2705,6 +2716,7 @@ module "lineagework" {
   lb_subnet_ids                          = local.internal_service_alb_subnet_ids
   lb_additional_security_group_ids       = concat(var.lineagework_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -2801,6 +2813,7 @@ module "metricwork" {
   lb_subnet_ids                          = local.internal_service_alb_subnet_ids
   lb_additional_security_group_ids       = concat(var.metricwork_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -2891,10 +2904,11 @@ module "rootcause" {
   ssl_policy                             = var.alb_ssl_policy
   acm_certificate_arn                    = local.acm_certificate_arn
   # revisit this after we observe the runtime, it likely can be much shorter (~5minute) since temporal respects sigterm and max runtime on API calls
-  lb_idle_timeout                  = var.lb_timeout
-  lb_subnet_ids                    = local.internal_service_alb_subnet_ids
-  lb_additional_security_group_ids = concat(var.rootcause_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
-  lb_additional_ingress_cidrs      = var.internal_additional_ingress_cidrs
+  lb_idle_timeout                   = var.lb_timeout
+  lb_subnet_ids                     = local.internal_service_alb_subnet_ids
+  lb_additional_security_group_ids  = concat(var.rootcause_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
+  lb_additional_ingress_cidrs       = var.internal_additional_ingress_cidrs
+  load_balancing_anomaly_mitigation = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -2990,6 +3004,7 @@ module "internalapi" {
   lb_additional_security_group_ids       = concat(var.internalapi_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
   lb_deregistration_delay                = 180
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket
@@ -3123,6 +3138,7 @@ module "lineageapi" {
   lb_additional_security_group_ids       = concat(var.lineageapi_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
   lb_additional_ingress_cidrs            = var.internal_additional_ingress_cidrs
   lb_deregistration_delay                = 90
+  load_balancing_anomaly_mitigation      = var.load_balancing_anomaly_mitigation
 
   lb_access_logs_enabled       = var.elb_access_logs_enabled
   lb_access_logs_bucket_name   = var.elb_access_logs_bucket

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -569,6 +569,12 @@ variable "lb_timeout" {
   type        = number
   default     = 900
 }
+
+variable "load_balancing_anomaly_mitigation" {
+  description = "Enable Anomaly mitigation LB algorithm on target groups.  LeastOutstandingRequests routing algorithm is used if set to false.  Cannot be used with session stickiness"
+  type        = bool
+  default     = false
+}
 #======================================================
 # Application Variables - Monocle
 #======================================================

--- a/modules/simpleservice/variables.tf
+++ b/modules/simpleservice/variables.tf
@@ -420,6 +420,12 @@ variable "lb_deregistration_delay" {
   default     = 60
 }
 
+variable "load_balancing_anomaly_mitigation" {
+  description = "Enable Anomaly mitigation LB algorithm on target groups.  LeastOutstandingRequests routing algorithm is used if set to false.  Cannot be used with session stickiness"
+  type        = bool
+  default     = false
+}
+
 variable "create_dns_records" {
   description = "Whether to set up DNS records"
   type        = bool


### PR DESCRIPTION
Anomaly mitigation is a newer routing feature on ALB which ideally solves both hot spots due to large requests as well as avoiding the case where a sick instance (like with a broken DB connection) can get a large percentage of inbound requests routed to it because it processes them very quickly and thus has the "least number of active connections".

This isn't available in conjunction with session stickiness so is not used on the frontend, but will set this everywhere else.

BREAKING CHANGE: The aws provider version upgrade is required in order to control the enable flag for this feature.