### PR TITLE
feat: normalize autoscaling config for api/ui facing services

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,29 @@ terraform version and application version.
 
 ## Upgrading
 
+### Upgrading to 21.0.0
+
+The AWS provider needs to be upgrade to support ALB anomaly mitigation.
+Upgrade your hashicorp/aws provider to 5.100.0 or newer.
+
+(Optional) The following are useful commands to avoid a service interruption
+from ECS replacing services when autoscaling is enabled.  It will also make
+the terraform apply run much faster.
+
+Run these before running terraform apply with `21.0.0`
+
+```bash
+terraform state mv \
+  'module.bigeye.module.datawatch.aws_ecs_service.controlled_count[0]' \
+  'module.bigeye.module.datawatch.aws_ecs_service.uncontrolled_count[0]'
+terraform state mv \
+  'module.bigeye.module.haproxy.aws_ecs_service.controlled_count[0]' \
+  'module.bigeye.module.haproxy.aws_ecs_service.uncontrolled_count[0]'
+terraform state mv \
+  'module.bigeye.module.web.aws_ecs_service.controlled_count[0]' \
+  'module.bigeye.module.web.aws_ecs_service.uncontrolled_count[0]'   
+```
+
 ### Upgrading to 20.0.0
 
 The following vars have been renamed from "ponts" to points" to fix typos.

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -869,6 +869,26 @@ variable "haproxy_lb_extra_security_group_ids" {
   default     = []
 }
 
+variable "haproxy_autoscaling_config" {
+  type = object({
+    min_capacity       = number
+    max_capacity       = number
+    type               = string
+    target_utilization = number
+  })
+  default = {
+    min_capacity = 2
+    max_capacity = 15
+    # If CPU scaling is leading to OOM or other overloading due to bursts, switch to request_count_per_target or increase the min capacity.
+    type               = "cpu_utilization"
+    target_utilization = 30
+  }
+  validation {
+    condition     = contains(["none", "cpu_utilization", "request_count_per_target"], var.haproxy_autoscaling_config.type)
+    error_message = "Must be one of: none, cpu_utilization, request_count_per_target"
+  }
+}
+
 #======================================================
 # Application Variables - Web
 #======================================================
@@ -925,6 +945,27 @@ variable "web_lb_extra_security_group_ids" {
   type        = list(string)
   default     = []
 }
+
+variable "web_autoscaling_config" {
+  type = object({
+    min_capacity       = number
+    max_capacity       = number
+    type               = string
+    target_utilization = number
+  })
+  default = {
+    min_capacity = 2
+    max_capacity = 15
+    # If CPU scaling is leading to OOM or other overloading due to bursts, switch to request_count_per_target or increase the min capacity.
+    type               = "cpu_utilization"
+    target_utilization = 30
+  }
+  validation {
+    condition     = contains(["none", "cpu_utilization", "request_count_per_target"], var.web_autoscaling_config.type)
+    error_message = "Must be one of: none, cpu_utilization, request_count_per_target"
+  }
+}
+
 
 #======================================================
 # Application Variables - TemporalUI
@@ -2527,7 +2568,7 @@ variable "internalapi_autoscaling_config" {
     max_capacity = 15
     # If CPU scaling is leading to OOM or other overloading due to bursts, switch to request_count_per_target or increase the min capacity.
     type               = "cpu_utilization"
-    target_utilization = 65
+    target_utilization = 30
   }
   validation {
     condition     = contains(["none", "cpu_utilization", "request_count_per_target"], var.internalapi_autoscaling_config.type)
@@ -2610,7 +2651,7 @@ variable "lineageapi_autoscaling_config" {
     max_capacity = 15
     # If CPU scaling is leading to OOM or other overloading due to bursts, switch to request_count_per_target or increase the min capacity.
     type               = "cpu_utilization"
-    target_utilization = 65
+    target_utilization = 30
   }
   validation {
     condition     = contains(["none", "cpu_utilization", "request_count_per_target"], var.lineageapi_autoscaling_config.type)


### PR DESCRIPTION
- Adds cpu autoscaling to web and haproxy services
- sets 30% cpu target as the default for autoscaling as 65 was a little slow to react since request counts can be sparse