### PR TITLE
fix: use vanity url for static assets when CDN is disabled

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1201,7 +1201,7 @@ module "web" {
       INSTANCE          = var.instance
       DOCKER_ENV        = var.environment
       APP_ENVIRONMENT   = var.environment
-      STATIC_ASSET_ROOT = "https://${var.create_dns_records ? aws_route53_record.static[0].fqdn : local.vanity_dns_name}"
+      STATIC_ASSET_ROOT = "https://${var.create_dns_records && var.cloudfront_enabled && var.cloudfront_route_static_asset_traffic ? aws_route53_record.static[0].fqdn : local.vanity_dns_name}"
       NODE_ENV          = "production"
       PORT              = var.web_port
       DROPWIZARD_HOST   = "https://${module.datawatch.dns_name}"


### PR DESCRIPTION
The static asset root should be set to the vanity url when Cloudfront is not in use.

Putting this behind the var.cloudfront_route_static_asset_traffic flag was missed in a previous PR.  What can happen is that during a blue/green deploy, static assets will 404 since session stickiness will not be respected if the STATIC_ASSET_ROOT does not match the main vanity url.