### PR TITLE
feat: add dedicated LB for external calls into Bigeye

### DIFF
--- a/modules/alarms/deprecated.tf
+++ b/modules/alarms/deprecated.tf
@@ -1,3 +1,9 @@
+variable "monitor_individual_external_lbs" {
+  description = "false will remove monitoring for the individual LBs and only monitor the centralized external lb.  This will be the default in a future release"
+  type        = bool
+  default     = true
+}
+
 variable "monitor_individual_internal_lbs" {
   description = "false will remove monitoring for the individual LBs and only monitor the centralized internal lb.  This will be the default in a future release"
   type        = bool

--- a/modules/alarms/main.tf
+++ b/modules/alarms/main.tf
@@ -690,8 +690,8 @@ module "elb_haproxy" {
   source                         = "./elb"
   stack                          = var.stack
   app                            = "haproxy"
-  lb_name                        = "${var.stack}-haproxy"
-  target_group_name              = "${var.stack}-haproxy"
+  lb_name                        = var.monitor_individual_external_lbs ? "${var.stack}-haproxy" : "${var.stack}-external"
+  target_group_name              = var.monitor_individual_external_lbs ? "${var.stack}-haproxy" : "${var.stack}-haproxy2"
   host_count_disabled            = var.elb_haproxy_host_count_disabled
   host_count_datapoints_to_alarm = var.elb_haproxy_host_count_datapoints_to_alarm
   host_count_evaluation_periods  = var.elb_haproxy_host_count_evaluation_periods

--- a/modules/bigeye/deprecated.tf
+++ b/modules/bigeye/deprecated.tf
@@ -1,3 +1,15 @@
+variable "use_centralized_external_lb" {
+  description = "This will migrate to using a single external LB instead of one per service.  This will be the default in a future release"
+  type        = bool
+  default     = false
+}
+
+variable "install_individual_external_lbs" {
+  description = "false will remove the external internal LBs.  This will be the default in a future release"
+  type        = bool
+  default     = true
+}
+
 variable "use_centralized_internal_lb" {
   description = "This will migrate to using a single internal LB instead of one per service.  This will be the default in a future release"
   type        = bool

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -30,6 +30,10 @@ locals {
   elasticache_subnet_group_name   = local.create_vpc ? module.vpc[0].elasticache_subnet_group_name : var.byovpc_redis_subnet_group_name
   rabbitmq_subnet_group_ids       = local.create_vpc ? module.vpc[0].elasticache_subnets : var.byovpc_rabbitmq_subnet_ids
 
+  external_alb_security_group_ids = concat(
+    var.create_security_groups ? [aws_security_group.external_alb[0].id] : [],
+    var.haproxy_extra_security_group_ids,
+  )
   internal_alb_ingress_cidrs = concat([var.vpc_cidr_block], var.internal_additional_ingress_cidrs)
   internal_alb_security_group_ids = concat(
     var.create_security_groups ? [aws_security_group.internal_alb[0].id] : [],

--- a/modules/simpleservice/data.tf
+++ b/modules/simpleservice/data.tf
@@ -1,4 +1,3 @@
 data "aws_lb" "external" {
-  count = local.centralized_lb_installed ? 1 : 0
-  arn   = var.centralized_lb_arn
+  arn = var.centralized_lb_arn
 }

--- a/modules/simpleservice/outputs.tf
+++ b/modules/simpleservice/outputs.tf
@@ -5,7 +5,7 @@ output "ecs_service_arn" {
 
 output "lb_dns_name" {
   description = "The DNS name of the load balancer"
-  value       = var.create_lb ? aws_lb.this[0].dns_name : data.aws_lb.external[0].dns_name
+  value       = var.create_lb ? aws_lb.this[0].dns_name : data.aws_lb.external.dns_name
 }
 
 output "dns_name" {
@@ -15,17 +15,17 @@ output "dns_name" {
 
 output "load_balancer_full_name" {
   description = "The load balancer full name, for use with CW metrics"
-  value       = var.use_centralized_lb ? data.aws_lb.external[0].arn_suffix : aws_lb.this[0].arn_suffix
+  value       = var.use_centralized_lb ? data.aws_lb.external.arn_suffix : aws_lb.this[0].arn_suffix
 }
 
 output "target_group_full_name" {
   description = "Target group full name, for use with CW metrics"
-  value       = var.use_centralized_lb ? aws_lb_target_group.centralized_lb[0].arn_suffix : aws_lb_target_group.this[0].arn_suffix
+  value       = var.use_centralized_lb ? aws_lb_target_group.centralized_lb.arn_suffix : aws_lb_target_group.this[0].arn_suffix
 }
 
 output "zone_id" {
   description = "The zone that the load balancer DNS is controlled"
-  value       = var.create_lb ? aws_lb.this[0].zone_id : data.aws_lb.external[0].zone_id
+  value       = var.create_lb ? aws_lb.this[0].zone_id : data.aws_lb.external.zone_id
 }
 
 output "security_group_id" {

--- a/modules/simpleservice/variables.tf
+++ b/modules/simpleservice/variables.tf
@@ -312,7 +312,6 @@ variable "centralized_lb_security_group_ids" {
 variable "centralized_lb_arn" {
   description = "external LB to import and create target groups and listeners for"
   type        = string
-  default     = ""
 }
 
 variable "centralized_lb_https_listener_rule_arn" {


### PR DESCRIPTION
This consolidation effort is a house cleaning effort to reduce the number of LBs for privatelink agents installs


commit 8ba9a47691d7e7187a6be8f9e111e0e6b07e4cde (HEAD -> david/external-lb-part2, origin/david/external-lb-part2)
Author: David Nguyen <david@bigeye.com>
Date:   Tue Jul 1 11:15:45 2025 -0700

    feat: add flags to migrate to centralized external LB

    These are cutover flags and the associated cleanup tasks
    required to apply clean.

    Deploy strategy to avoid a service interruption:

    1) terraform apply as-is - this will create the centralized external
    loadbalancer and target group

    2) add var.use_centralized_external_lb = true and run terraform apply
    again.  This will cutover to using the centralized external LB

    3) add var.install_individual_external_lbs = false.  This will
    delete the unneeded old external LB and TG.

commit 2f44d358e96a624ba83080a15e086348e78f1780 (origin/david/sre-4888-set-up-dedicated-external-lb, david/sre-4888-set-up-dedicated-external-lb)
Author: David Nguyen <david@bigeye.com>
Date:   Tue May 6 09:40:29 2025 -0700

    feat: add dedicated LB for external calls into Bigeye - part 1

    This will mirror the pattern used for the internal LB which is
    a single LB with path based routing instead of LB per service.

    Overall this is a cost savings architecture improvement and does
    not improve performance/scalability outside of being more thrifty
    with internal IPs that each LB uses.