### PR TITLE
feat: add flag to enable additional debugging stats for java services

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2368,6 +2368,7 @@ locals {
     REQUEST_BODY_LOGGING_ENABLED    = true
     CLASS_LOADING_LOGGING_ENABLED   = var.datawatch_class_loading_logging_enabled
     MAX_REQUEST_SIZE                = var.datawatch_max_request_size
+    ENABLE_EXTRA_METRICS            = var.datadog_java_service_extra_metrics_enabled
 
     AUTH0_DOMAIN            = var.auth0_domain
     EXTERNAL_LOGGING_LEVEL  = var.datawatch_external_logging_level

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -313,6 +313,12 @@ variable "datadog_agent_api_key_secret_arn" {
   default     = ""
 }
 
+variable "datadog_java_service_extra_metrics_enabled" {
+  description = "Additional stats can be sent to Datadog for system internals such as JDBC pool utilization etc.  Warning - this may run up your Datadog custom metrics bill if enabled."
+  type        = bool
+  default     = false
+}
+
 #======================================================
 # AWS Firelens settings
 #======================================================


### PR DESCRIPTION
This will enable stats such as jdbc connection pool utiliazation to be emitted to Datadog.