### PR TITLE
fix: skip sending previous version to triggered deploy job

### DIFF
--- a/.github/workflows/test_and_publish.yaml
+++ b/.github/workflows/test_and_publish.yaml
@@ -140,7 +140,7 @@ jobs:
       - name: notify SDP
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: |
-          gh workflow run "TF Bump Module Version" -R "bigeyedata/semantic-data-platform" --field "previousVersion=${{ steps.prevversion.outputs.PREVIOUS_VERSION }}" --field "version=${{ steps.changelog.outputs.tag }}"
+          gh workflow run "TF Bump Module Version" -R "bigeyedata/semantic-data-platform" --field "version=${{ steps.changelog.outputs.tag }}"
         env:
           GITHUB_TOKEN: ${{ secrets.BIGEYE_SRE_BOT_GH_PAT }}
       - name: failure - delete branch and tag


### PR DESCRIPTION
This flag is deprecated and doesn't do anything anymore.