### PR TITLE
fix: fix metacenter-solr access

### DIFF
--- a/modules/bigeye/deprecated.tf
+++ b/modules/bigeye/deprecated.tf
@@ -58,3 +58,10 @@ variable "load_balancing_anomaly_mitigation" {
   type        = bool
   default     = true
 }
+
+# ready for removal
+variable "lineageplus_solr_cnames" {
+  description = "Deprecated.  Use var.lineageplus_solr_aliases"
+  type        = list(string)
+  default     = []
+}

--- a/modules/bigeye/lineageplus.tf
+++ b/modules/bigeye/lineageplus.tf
@@ -20,7 +20,7 @@ module "lineageplus_solr" {
   acm_certificate_arn = local.acm_certificate_arn
   dns_name            = var.create_dns_records ? local.lineageplus_solr_dns_name : ""
   route53_zone_id     = var.create_dns_records ? data.aws_route53_zone.this[0].id : ""
-  solr_cnames         = var.create_dns_records ? var.lineageplus_solr_cnames : []
+  solr_aliases        = var.create_dns_records ? concat(var.lineageplus_solr_aliases, var.lineageplus_solr_cnames) : []
 
   lb_access_logs_enabled                 = var.elb_access_logs_enabled
   lb_access_logs_bucket_name             = var.elb_access_logs_bucket

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2817,8 +2817,8 @@ variable "lineageplus_solr_ebs_volume_size_os" {
   default     = 40
 }
 
-variable "lineageplus_solr_cnames" {
-  description = "CNAME Route53 records that will point to the main service DNS name."
+variable "lineageplus_solr_aliases" {
+  description = "Legacy DNS names for solr."
   type        = list(string)
   default     = []
 }

--- a/modules/solr-single-instance/variables.tf
+++ b/modules/solr-single-instance/variables.tf
@@ -149,8 +149,8 @@ variable "dns_name" {
   default     = ""
 }
 
-variable "solr_cnames" {
-  description = "CNAME Route53 records that will point to the main service DNS name."
+variable "solr_aliases" {
+  description = "Legacy DNS names for solr"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
The metacenter address is legacy, but must continue to be supported as existing lineageplus customers are using it.

1) There is no reason to use a CNAME in one place, but an alias record in another, let's consolidate and use the same record for all aliases

2) The external LB was missing the legacy metacenter hostname based routing rule