### PR TITLE
fix: update S3 perms and add object versioning

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -185,12 +185,16 @@ locals {
   models_bucket_name              = local.models_bucket_has_name_override ? var.ml_models_s3_bucket_name_override : "${local.name}-models"
   s3_buckets = [
     {
+      # Used to store trained models for Authresholds
       "type" : "models"
       "retention_days" : 45
       }, {
+      # Agent large payloads are published here via datawatch.  This is also being used as general
+      # purpose storage going forward so other features do write to this bucket as well.
       "type" : "large-payload"
       "retention_days" : 7
       }, {
+      # MCP gateway service publishes telemetry here via datawatch.
       "type" : "mcp-gateway"
       "retention_days" : 30
     }

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1911,13 +1911,21 @@ resource "aws_iam_role_policy" "datawatch_s3" {
         Resource = [for bucket_name in local.datawatch_buckets : module.s3_buckets[bucket_name].arn]
       },
       {
-        Sid    = "AllowGetPutObjects"
+        Sid    = "AllowRWObjects"
         Effect = "Allow"
         Action = [
           "s3:GetObject",
           "s3:PutObject"
         ]
         Resource = [for bucket_name in local.datawatch_buckets : format("%s/*", module.s3_buckets[bucket_name].arn)]
+      },
+      {
+        Sid    = "AllowDeleteObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:DeleteObject"
+        ]
+        Resource = [for bucket_name in local.datawatch_buckets : format("%s/*", module.s3_buckets[bucket_name].arn) if bucket_name != "mcp-gateway"]
       }
     ]
   })

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -38,6 +38,16 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     expiration {
       days = var.retention_days
     }
+    noncurrent_version_expiration {
+      noncurrent_days = var.retention_days
+    }
     filter {}
+  }
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }


### PR DESCRIPTION
The agent large payload bucket is actually a general purpose bucket and some of the lineage processing jobs do clean up after themselves.

We also want to add object versioning to have a record of mutations for forensics.