### PR TITLE
fix!: allow removal of 0.0.0.0/0 from ingress cidr range

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ the Bigeye stack into an AWS Environment.
 [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli#install-terraform)
 
 - at least version 1.0. We find that
-([tfenv](https://github.com/tfutils/tfenv)) is a useful way to install
+  ([tfenv](https://github.com/tfutils/tfenv)) is a useful way to install
   & manage Terraform versions
 
 ### AWS
 
-You need the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+You need
+the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 installed and configured with credentials for your AWS account.
 
 ## Getting Started
@@ -49,6 +50,22 @@ terraform version and application version.
 
 ## Upgrading
 
+### Upgrading to 24.0.0
+
+The following vars have been renamed.
+
+- `var.additional_ingress_cidrs` to `var.external_ingress_cidrs`
+- `var.internal_extra_security_group_ids` to
+  `var.internal_additional_security_group_ids`
+- `var.temporal_lb_extra_security_group_ids` to
+  `var.external_additional_security_group_ids`
+
+Also note that if you have set `var.additional_ingress_cidrs`,
+0.0.0.0/0 will now be removed from external load balancer ingress.
+
+`var.external_additional_security_group_ids` controls access to
+both the external ALB and NLB.
+
 ### Upgrading to 23.0.0
 
 The following vars have been removed from the bigeye module:
@@ -78,7 +95,7 @@ The AWS provider needs to be upgrade to support ALB anomaly mitigation.
 Upgrade your hashicorp/aws provider to 5.100.0 or newer.
 
 (Optional) The following are useful commands to avoid a service interruption
-from ECS replacing services when autoscaling is enabled.  It will also make
+from ECS replacing services when autoscaling is enabled. It will also make
 the terraform apply run much faster.
 
 Run these before running terraform apply with `21.0.0`
@@ -137,11 +154,11 @@ down the road.
 ### Upgrading to 18.0.0
 
 18.0.0 is the first step in a 2 part series to migrate from inline security
-group rules to dedicated rules.  The inline rules do not track AWS rule Ids
-properly which blocks seamless changes.  More can be read on this in the
+group rules to dedicated rules. The inline rules do not track AWS rule Ids
+properly which blocks seamless changes. More can be read on this in the
 [Terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule)
 
-> IMPORTANT - Apply this plan 1x only.  Then apply 19.0.0
+> IMPORTANT - Apply this plan 1x only. Then apply 19.0.0
 
 The migration path from inline rules involves setting the inline rules to
 empty lists. But this will fight with the dedicated ingress/egress rules so
@@ -151,7 +168,7 @@ idempotent again.
 ### Upgrading to 17.0.0
 
 The minimum version of the `hashicorp/aws` module has been increased to
-5.68.0.  If your install has the version pinned to something lower,
+5.68.0. If your install has the version pinned to something lower,
 increase the version to at least 5.68.0 and run `terraform init -upgrade`.
 
 ### Upgrading to 16.0.0
@@ -204,7 +221,8 @@ are using them:
 
 ### Upgrading to 10.0.0
 
-All variables with papi in the name need to be globally replaced with internalapi.
+All variables with papi in the name need to be globally replaced with
+internalapi.
 
 ### Upgrading to 1.0.0
 

--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -32,12 +32,12 @@ locals {
 
   external_alb_security_group_ids = concat(
     var.create_security_groups ? [aws_security_group.external_alb[0].id] : [],
-    var.haproxy_extra_security_group_ids,
+    var.external_additional_security_group_ids,
   )
   internal_alb_ingress_cidrs = concat([var.vpc_cidr_block], var.internal_additional_ingress_cidrs)
   internal_alb_security_group_ids = concat(
     var.create_security_groups ? [aws_security_group.internal_alb[0].id] : [],
-    var.internal_extra_security_group_ids,
+    var.internal_additional_security_group_ids,
   )
 
   # Temporal Task Queues

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -186,11 +186,6 @@ data "aws_vpc" "this" {
     }
 
     postcondition {
-      condition     = var.create_security_groups || length(var.temporal_lb_extra_security_group_ids) > 0
-      error_message = "If create_security_groups is false, you must provide a security group for the temporal lb using temporal_lb_extra_security_group_ids (port 443)"
-    }
-
-    postcondition {
       condition     = var.create_security_groups || length(var.scheduler_lb_extra_security_group_ids) > 0
       error_message = "If create_security_groups is false, you must provide a security group for the scheduler lb using scheduler_lb_extra_security_group_ids (ports 80/443)"
     }
@@ -805,7 +800,7 @@ resource "aws_vpc_security_group_egress_rule" "external_alb_egress" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "external_alb_ingress_cidrs_http" {
-  for_each          = var.create_security_groups ? var.internet_facing ? ["0.0.0.0/0"] : toset(concat([var.vpc_cidr_block], var.additional_ingress_cidrs)) : []
+  for_each          = var.create_security_groups ? var.internet_facing ? toset(var.external_ingress_cidrs) : toset(concat([var.vpc_cidr_block], var.external_ingress_cidrs)) : []
   security_group_id = aws_security_group.external_alb[0].id
   from_port         = 80
   to_port           = 80
@@ -814,7 +809,7 @@ resource "aws_vpc_security_group_ingress_rule" "external_alb_ingress_cidrs_http"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "external_alb_ingress_cidrs_https" {
-  for_each          = var.create_security_groups ? var.internet_facing ? ["0.0.0.0/0"] : toset(concat([var.vpc_cidr_block], var.additional_ingress_cidrs)) : []
+  for_each          = var.create_security_groups ? var.internet_facing ? toset(var.external_ingress_cidrs) : toset(concat([var.vpc_cidr_block], var.external_ingress_cidrs)) : []
   security_group_id = aws_security_group.external_alb[0].id
   from_port         = 443
   to_port           = 443

--- a/modules/bigeye/temporal.tf
+++ b/modules/bigeye/temporal.tf
@@ -11,7 +11,7 @@ resource "aws_lb" "temporal" {
   load_balancer_type               = "network"
   subnets                          = var.temporal_internet_facing ? local.public_alb_subnet_ids : local.internal_service_alb_subnet_ids
   enable_cross_zone_load_balancing = true
-  security_groups                  = concat(aws_security_group.temporal_lb[*].id, var.temporal_lb_extra_security_group_ids, [module.bigeye_admin.client_security_group_id])
+  security_groups                  = concat(aws_security_group.temporal_lb[*].id, var.external_additional_security_group_ids, [module.bigeye_admin.client_security_group_id])
   tags                             = merge(local.tags, { app = "temporal", component = "frontend" })
 
   access_logs {
@@ -219,11 +219,11 @@ resource "aws_security_group" "temporal_lb" {
   })
 
   ingress {
-    description = "Traffic port open to anywhere"
+    description = "Traffic port open from external"
     from_port   = local.temporal_lb_port
     to_port     = local.temporal_lb_port
     protocol    = "TCP"
-    cidr_blocks = var.temporal_internet_facing ? ["0.0.0.0/0"] : concat([var.vpc_cidr_block], var.additional_ingress_cidrs)
+    cidr_blocks = var.temporal_internet_facing ? var.external_ingress_cidrs : concat([var.vpc_cidr_block], var.external_ingress_cidrs)
   }
 
   egress {

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -72,8 +72,14 @@ variable "create_security_groups" {
   default     = true
 }
 
-variable "additional_ingress_cidrs" {
-  description = "This setting allows additional CIDR blocks to ingress to the load balancers for the application. A common use case here is when the internet_facing is false, and ingress from a VPN must be allowed"
+variable "external_ingress_cidrs" {
+  description = "Setting this variable allows replacing the allowed ingress cidrs to the external load balancers for the application. A common use case here is when the internet_facing is false, and ingress from a VPN must be allowed"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "external_additional_security_group_ids" {
+  description = "Additional security group ids to attach to internal load balancers"
   type        = list(string)
   default     = []
 }
@@ -84,7 +90,7 @@ variable "internal_additional_ingress_cidrs" {
   default     = []
 }
 
-variable "internal_extra_security_group_ids" {
+variable "internal_additional_security_group_ids" {
   description = "Additional security group ids to attach to internal load balancers"
   type        = list(string)
   default     = []
@@ -1362,12 +1368,6 @@ variable "temporal_additional_secret_arns" {
 
 variable "temporal_extra_security_group_ids" {
   description = "Additional security group IDs to give to temporal"
-  type        = list(string)
-  default     = []
-}
-
-variable "temporal_lb_extra_security_group_ids" {
-  description = "Additional security group IDs to give to temporal LB"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
    fix!: allow removal of 0.0.0.0/0 from ingress cidr range

    The current variable var.additional_ingress_cidrs allows the user
    to specify additional cidr ranges to allow ingress from, but does
    not allow removal of a "wide-open" cidr block.

    This PR changes "additional_ingress_cidrs" to "external_ingress_cidrs"
    to make it clear that setting this variable, replaces the default
    ingress cidr range 0.0.0.0/0 on the external LB.

    It also fixes a bug where the Temporal LB did not respect this variable.

    In addition, a new variable var.external_additional_security_group_ids
    replaces `var.temporal_lb_extra_security_group_ids`.  This variable
    controls access to both the external ALB and NLB so there is only one
    variable set now.  This matches the behavior of
    `var.external_ingress_cidrs`

    BREAKING CHANGE:
    The following vars have been renamed.

    - `var.additional_ingress_cidrs` to `var.external_ingress_cidrs`
    - `var.internal_extra_security_group_ids` to
    `var.internal_extra_security_group_ids`
    - var.temporal_lb_extra_security_group_ids to
    `var.external_additional_security_group_ids`

    Also note that if you have set `var.additional_ingress_cidrs`,
    0.0.0.0/0 will now be removed from external load balancer ingress.

    `var.external_additional_security_group_ids` controls access to
    both the external ALB and NLB.