### PR TITLE
feat: new environment variables for configuring hibernate search

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -296,6 +296,9 @@ locals {
   temporal_system_visibility_persistence_max_read_qps  = var.temporal_system_visibility_persistence_max_read_qps
   temporal_system_visibility_persistence_max_write_qps = var.temporal_system_visibility_persistence_max_write_qps
 
+  hibernate_search_coordination             = var.hibernate_search_coordination
+  hibernate_search_event_processor_enabled  = var.hibernate_search_event_processor_enabled
+  hibernate_search_event_processor_interval = var.hibernate_search_event_processor_interval
 
   #======================================================
   # Datadog specs

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2316,6 +2316,10 @@ locals {
     MYSQL_MAXSIZE               = var.datawatch_mysql_maxsize
     MYSQL_TRANSACTION_ISOLATION = "read-committed"
 
+    HIBERNATE_SEARCH_COORDINATION             = local.hibernate_search_coordination
+    HIBERNATE_SEARCH_EVENT_PROCESSOR_ENABLED  = local.hibernate_search_event_processor_enabled
+    HIBERNATE_SEARCH_EVENT_PROCESSOR_INTERVAL = local.hibernate_search_event_processor_interval
+
     MONOCLE_ADDRESS   = "https://${module.monocle.dns_name}"
     REDIRECT_ADDRESS  = "https://${local.vanity_dns_name}"
     SCHEDULER_ADDRESS = "https://${module.scheduler.dns_name}"

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -594,6 +594,24 @@ variable "spot_instance_config" {
   }
 }
 
+variable "hibernate_search_coordination" {
+  description = "algorithm to use for hibernate search coordination"
+  type        = string
+  default     = "none"
+}
+
+variable "hibernate_search_event_processor_enabled" {
+  description = "enable background threads for processing hibernate search events"
+  type        = bool
+  default     = false
+}
+
+variable "hibernate_search_event_processor_interval" {
+  description = "interval in milliseconds that hibernate search event processor will check for events"
+  type        = number
+  default     = 1000
+}
+
 #======================================================
 # Application Variables - Monocle
 #======================================================


### PR DESCRIPTION
My intention is to add some new environment variables to use for configuring Hibernate Search. These environment variables are referenced in `aws.yaml`.

The coordination setting `HIBERNATE_SEARCH_COORDINATION` will be set the same for all Java service stacks. 

The setting `HIBERNATE_SEARCH_EVENT_PROCESSOR_ENABLED`, which will enable background Hibernate Search threads to read from the search event table, and push the event data to Elasticsearch, will only be set on one stack. 

The setting `HIBERNATE_SEARCH_EVENT_PROCESSOR_INTERVAL` controls how often event processor threads will check the event table.

Hibernate search will first be enabled in staging only, and event processors will only be enabled for staging datawork. Enabling for staging datawork will involve setting `HIBERNATE_SEARCH_EVENT_PROCESSOR_ENABLED` in `datawork_additional_environment_vars` in `staging-staging/main.tf`.