### PR TITLE
feat: add MAX_SIGNUP_COMPANIES env var for datawatch instances

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2343,6 +2343,7 @@ locals {
     REQUEST_BODY_LOGGING_ENABLED    = true
     CLASS_LOADING_LOGGING_ENABLED   = var.datawatch_class_loading_logging_enabled
     MAX_REQUEST_SIZE                = var.datawatch_max_request_size
+    MAX_SIGNUP_COMPANIES            = var.datawatch_max_signup_companies
     ENABLE_EXTRA_METRICS            = var.datadog_java_service_extra_metrics_enabled
 
     AUTH0_DOMAIN            = var.auth0_domain

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -2178,6 +2178,12 @@ variable "datawatch_max_request_size" {
   type        = string
 }
 
+variable "datawatch_max_signup_companies" {
+  description = "Maximum number of companies allowed to sign up. Set to 0 for unlimited."
+  default     = 0
+  type        = number
+}
+
 variable "datawatch_temporal_large_payload_enabled" {
   description = "Controls if datawatch common services have the temporal large payload converter enabled.  It is not common to deviate from the default setting."
   type        = bool


### PR DESCRIPTION
## Summary
- Adds new `datawatch_max_signup_companies` Terraform variable (type `number`, default `0` for unlimited)
- Passes `MAX_SIGNUP_COMPANIES` into the datawatch common environment variables
- Per-stack overrides work via `datawatch_max_signup_companies = <value>` in the module call

## Test plan
- [ ] Verify `terraform plan` shows `MAX_SIGNUP_COMPANIES = 0` in the datawatch task definition for a stack using defaults
- [ ] Verify setting `datawatch_max_signup_companies = 100` in a stack overrides the value correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)