### PR TITLE
[SRE-6999] Pin datawatch RDS sql_mode in module defaults

### DIFF
--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1937,6 +1937,10 @@ variable "datawatch_rds_default_parameters" {
       value        = 1
       apply_method = "pending-reboot"
     }
+    sql_mode = {
+      value        = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+      apply_method = "immediate"
+    }
   }
 }
 
@@ -2015,6 +2019,10 @@ variable "datawatch_rds_replica_default_parameters" {
     skip_name_resolve = {
       value        = 1
       apply_method = "pending-reboot"
+    }
+    sql_mode = {
+      value        = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+      apply_method = "immediate"
     }
   }
 }


### PR DESCRIPTION
  ## Why
  Today `sql_mode` is not set anywhere in our Terraform, so MySQL falls back to whatever the engine ships as default. On the `8.0.40` and `8.4.9` engines we currently run, that default is:

  `ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION`

We've been running with `ONLY_FULL_GROUP_BY` enabled for the entire life of these stacks - neither the Java app nor Python services reference `sql_mode` anywhere (verified via grep across `java/`, `python/`, all yaml/properties/JDBC URLs). Per Backend Weekly (SRE-6999), we want to lock this in explicitly so:
  - A future engine-default change (e.g. the upcoming 8.0 → 8.4 rollout, or any later bump) can't silently shift sql_mode under us.
  - The primary and replica parameter groups stay in sync.