### PR TITLE
feat: wire up Temporal connection settings for monocle and toretto

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1472,6 +1472,8 @@ module "monocle" {
       WORKERS                    = var.monocle_worker_count == 0 ? var.monocle_cpu * 2 / 1024 : 2
       TIMEOUT                    = "900"
       DATAWATCH_ADDRESS          = "https://${module.internalapi.dns_name}"
+      TEMPORAL_ADDRESS           = "${local.temporal_dns_name}:${local.temporal_lb_port}"
+      TEMPORAL_NAMESPACE         = var.temporal_namespace
     },
     local.sentry_event_level_env_variable,
     var.datadog_agent_enabled ? {
@@ -1491,8 +1493,9 @@ module "monocle" {
     local.sentry_dsn_secret_map,
     local.stitch_secrets_map,
     {
-      MQ_BROKER_PASSWORD = local.rabbitmq_user_password_secret_arn
-      ROBOT_PASSWORD     = local.robot_password_secret_arn
+      MQ_BROKER_PASSWORD  = local.rabbitmq_user_password_secret_arn
+      ROBOT_PASSWORD      = local.robot_password_secret_arn
+      ROBOT_AGENT_API_KEY = local.robot_agent_apikey_secret_arn
     },
     var.datadog_agent_enabled ? {
       DATADOG_API_KEY = var.datadog_agent_api_key_secret_arn
@@ -1627,6 +1630,8 @@ module "toretto" {
       WORKERS                    = "1"
       TIMEOUT                    = "900"
       DATAWATCH_ADDRESS          = "https://${module.internalapi.dns_name}"
+      TEMPORAL_ADDRESS           = "${local.temporal_dns_name}:${local.temporal_lb_port}"
+      TEMPORAL_NAMESPACE         = var.temporal_namespace
     },
     local.sentry_event_level_env_variable,
     var.toretto_additional_environment_vars,
@@ -1636,8 +1641,9 @@ module "toretto" {
     local.sentry_dsn_secret_map,
     local.stitch_secrets_map,
     {
-      MQ_BROKER_PASSWORD = local.rabbitmq_user_password_secret_arn
-      ROBOT_PASSWORD     = local.robot_password_secret_arn
+      MQ_BROKER_PASSWORD  = local.rabbitmq_user_password_secret_arn
+      ROBOT_PASSWORD      = local.robot_password_secret_arn
+      ROBOT_AGENT_API_KEY = local.robot_agent_apikey_secret_arn
     },
     var.datadog_agent_enabled ? { DATADOG_API_KEY = var.datadog_agent_api_key_secret_arn } : {},
     var.toretto_additional_secret_arns,


### PR DESCRIPTION
## Summary
- Add `TEMPORAL_ADDRESS` and `TEMPORAL_NAMESPACE` env vars to the monocle and toretto ECS task definitions, matching the naming their Python config layer expects and the values already computed for other Temporal clients (datawatch, temporalui).
- Add the `ROBOT_AGENT_API_KEY` secret to both services, matching the pattern already used by datawatch and the other worker services, since the Temporal frontend is configured with `TEMPORAL_AUTH_CLAIM_MAPPER = "apikey"` and requires that credential to authenticate.

Monocle and toretto maintain their own `environment_variables`/`secret_arns` blocks (rather than sharing `local.datawatch_common_env_vars`/`datawatch_secret_arns` like the other worker services), which is why they were missing this config previously.

## Test plan
- [x] `terraform fmt -check` passes on `modules/bigeye/main.tf`
- [ ] `terraform plan` against a real state to confirm only the expected env var / secret diffs appear on the monocle and toretto ECS task definitions
- [ ] Verify monocle/toretto can connect to Temporal using `TEMPORAL_ADDRESS`/`TEMPORAL_NAMESPACE`/`ROBOT_AGENT_API_KEY` once the corresponding Python client support lands