### PR TITLE
fix: grant monocle/toretto task role read access to agent secrets

### DIFF
--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -1377,6 +1377,28 @@ resource "aws_iam_role_policy" "monocle" {
   })
 }
 
+resource "aws_iam_role_policy" "monocle_secrets" {
+  count = local.create_monocle_role ? 1 : 0
+  role  = aws_iam_role.monocle[0].id
+  name  = "AllowReadAgentSecrets"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowReadSecrets"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = [
+          "arn:${data.aws_partition.current.partition}:secretsmanager:${local.aws_region}:${local.aws_account_id}:secret:bigeye/${local.name}/agent/*"
+        ]
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role_policy" "monocle_ecs_exec" {
   count = local.create_monocle_role && (var.monocle_enable_ecs_exec || var.toretto_enable_ecs_exec) ? 1 : 0
   role  = aws_iam_role.monocle[0].id


### PR DESCRIPTION
## Summary
- The shared `monocle`/`toretto` ECS task role (`aws_iam_role.monocle`) had no `secretsmanager` permissions at all, only S3 access to the models bucket.
- This caused `AccessDeniedException` when monocle/toretto tried `secretsmanager:GetSecretValue` on `bigeye/<name>/agent/*` secrets (e.g. `bigeye/staging-staging/agent/public`), which are created/managed by the `datawatch` role.
- Adds a new `aws_iam_role_policy.monocle_secrets` granting `secretsmanager:DescribeSecret`/`GetSecretValue` on `bigeye/${local.name}/agent/*`, mirroring the existing `datawatch_secrets` read policy.

## Test plan
- [x] `terraform fmt -check` clean
- [x] `terraform init -backend=false && terraform validate` passes
- [ ] `terraform plan` against staging to confirm only the new IAM policy is added
- [ ] Confirm monocle/toretto can successfully call `GetSecretValue` on `bigeye/staging-staging/agent/public` after apply