### PR TITLE
feat: new Temporal environment variable 

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -288,6 +288,7 @@ locals {
   temporal_frontend_rps                                = var.temporal_frontend_rps
   temporal_frontend_namespace_rps                      = var.temporal_frontend_namespace_rps
   temporal_frontend_burst_ratio                        = var.temporal_frontend_burst_ratio
+  temporal_frontend_namespace_visibility_rps           = var.temporal_frontend_namespace_visibility_rps
   temporal_frontend_persistence_max_qps                = var.temporal_frontend_persistence_max_qps
   temporal_history_persistence_max_qps                 = var.temporal_history_persistence_max_qps
   temporal_matching_rps                                = var.temporal_matching_rps

--- a/modules/bigeye/temporal.tf
+++ b/modules/bigeye/temporal.tf
@@ -376,6 +376,7 @@ locals {
       TEMPORAL_FRONTEND_RPS                                = tostring(local.temporal_frontend_rps)
       TEMPORAL_FRONTEND_NAMESPACE_RPS                      = tostring(local.temporal_frontend_namespace_rps)
       TEMPORAL_FRONTEND_BURST_RATIO                        = tostring(local.temporal_frontend_burst_ratio)
+      TEMPORAL_FRONTEND_NAMESPACE_VISIBILITY_RPS           = tostring(local.temporal_frontend_namespace_visibility_rps)
       TEMPORAL_FRONTEND_PERSISTENCE_MAX_QPS                = local.temporal_frontend_persistence_max_qps
       TEMPORAL_HISTORY_PERSISTENCE_MAX_QPS                 = local.temporal_history_persistence_max_qps
       TEMPORAL_MATCHING_RPS                                = local.temporal_matching_rps

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1504,6 +1504,12 @@ variable "temporal_frontend_namespace_rps" {
   default     = 2400
 }
 
+variable "temporal_frontend_namespace_visibility_rps" {
+  description = "FrontendMaxNamespaceVisibilityRPSPerInstance is namespace rate limit per second for visibility APIs. This config is EXPERIMENTAL and may be changed or removed in a later release."
+  type        = number
+  default     = 10
+}
+
 variable "temporal_frontend_burst_ratio" {
   description = "FrontendMaxNamespaceBurstRatioPerInstance is workflow namespace burst limit as a ratio of namespace RPS. The RPS used here will be the effective RPS from global and per-instance limits. The value must be 1 or higher."
   type        = number


### PR DESCRIPTION
For frontend namespace visibility rps, which determines how many times we can list schedules per second. 