### PR TITLE
Add REMEMBER_ME_CIPHER_KEY to datawatch envs

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -116,6 +116,8 @@ locals {
   robot_password_secret_arn              = local.create_robot_password_secret ? aws_secretsmanager_secret.robot_password[0].arn : var.datawatch_robot_password_secret_arn
   create_robot_agent_apikey_secret       = var.datawatch_robot_agent_api_key_secret_arn == ""
   robot_agent_apikey_secret_arn          = local.create_robot_agent_apikey_secret ? aws_secretsmanager_secret.robot_agent_api_key[0].arn : var.datawatch_robot_agent_api_key_secret_arn
+  create_remember_me_cipher_key_secret   = var.datawatch_remember_me_cipher_key_secret_arn == ""
+  remember_me_cipher_key_secret_arn      = local.create_remember_me_cipher_key_secret ? aws_secretsmanager_secret.remember_me_cipher_key[0].arn : var.datawatch_remember_me_cipher_key_secret_arn
   create_datawatch_encryption_key_secret = var.datawatch_encryption_key_arn == ""
   datawatch_encryption_key_secret_arn    = local.create_datawatch_encryption_key_secret ? aws_secretsmanager_secret.datawatch_encryption_key[0].arn : var.datawatch_encryption_key_arn
   datawatch_encryption_key_secret_name   = local.create_datawatch_encryption_key_secret ? aws_secretsmanager_secret.datawatch_encryption_key[0].name : data.aws_secretsmanager_secret.datawatch_encryption_key[0].name
@@ -273,6 +275,7 @@ locals {
       MYSQL_PASSWORD         = local.datawatch_rds_password_secret_arn
       ROBOT_PASSWORD         = local.robot_password_secret_arn
       ROBOT_AGENT_API_KEY    = local.robot_agent_apikey_secret_arn
+      REMEMBER_ME_CIPHER_KEY = local.remember_me_cipher_key_secret_arn
       BASE_SALT              = local.base_datawatch_salt_secret_arn
       ELASTICSEARCH_PASSWORD = local.create_temporal_opensearch_password_secret ? aws_secretsmanager_secret_version.temporal_opensearch_password[0].arn : data.aws_secretsmanager_secret_version.byo_temporal_opensearch_password[0].arn
     },

--- a/modules/bigeye/main.tf
+++ b/modules/bigeye/main.tf
@@ -2257,6 +2257,23 @@ resource "aws_secretsmanager_secret_version" "robot_password" {
   version_stages = ["AWSCURRENT"]
 }
 
+resource "random_id" "remember_me_cipher_key" {
+  count       = local.create_remember_me_cipher_key_secret ? 1 : 0
+  byte_length = 16
+}
+resource "aws_secretsmanager_secret" "remember_me_cipher_key" {
+  count                   = local.create_remember_me_cipher_key_secret ? 1 : 0
+  name                    = format("bigeye/%s/datawatch/remember-me-cipher-key", local.name)
+  recovery_window_in_days = local.secret_retention_days
+  tags                    = local.tags
+}
+resource "aws_secretsmanager_secret_version" "remember_me_cipher_key" {
+  count          = local.create_remember_me_cipher_key_secret ? 1 : 0
+  secret_id      = aws_secretsmanager_secret.remember_me_cipher_key[0].id
+  secret_string  = random_id.remember_me_cipher_key[0].b64_std
+  version_stages = ["AWSCURRENT"]
+}
+
 resource "random_password" "robot_agent_api_key" {
   count   = local.create_robot_agent_apikey_secret ? 1 : 0
   length  = 40
@@ -2415,7 +2432,7 @@ locals {
 }
 
 module "datawatch" {
-  depends_on       = [aws_secretsmanager_secret_version.robot_password]
+  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.remember_me_cipher_key]
   source           = "../simpleservice"
   cpu_architecture = lookup(var.cpu_architecture_overrides, "datawatch", var.cpu_architecture)
   app              = "datawatch"
@@ -2543,7 +2560,7 @@ resource "aws_appautoscaling_policy" "datawatch_request_count_per_target" {
 }
 
 module "datawork" {
-  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key]
+  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key, aws_secretsmanager_secret_version.remember_me_cipher_key]
   source           = "../simpleservice"
   cpu_architecture = lookup(var.cpu_architecture_overrides, "datawork", var.cpu_architecture)
   app              = "datawork"
@@ -2655,7 +2672,7 @@ module "datawork" {
 }
 
 module "backfillwork" {
-  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key]
+  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key, aws_secretsmanager_secret_version.remember_me_cipher_key]
   source           = "../simpleservice"
   cpu_architecture = lookup(var.cpu_architecture_overrides, "backfillwork", var.cpu_architecture)
   app              = "backfillwork"
@@ -2735,7 +2752,7 @@ module "backfillwork" {
 }
 
 module "indexwork" {
-  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key]
+  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key, aws_secretsmanager_secret_version.remember_me_cipher_key]
   source           = "../simpleservice"
   cpu_architecture = lookup(var.cpu_architecture_overrides, "indexwork", var.cpu_architecture)
   app              = "indexwork"
@@ -2820,7 +2837,7 @@ module "indexwork" {
 }
 
 module "lineagework" {
-  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key]
+  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key, aws_secretsmanager_secret_version.remember_me_cipher_key]
   source           = "../simpleservice"
   cpu_architecture = lookup(var.cpu_architecture_overrides, "lineagework", var.cpu_architecture)
   app              = "lineagework"
@@ -2911,7 +2928,7 @@ module "lineagework" {
 }
 
 module "metricwork" {
-  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key]
+  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key, aws_secretsmanager_secret_version.remember_me_cipher_key]
   source           = "../simpleservice"
   cpu_architecture = lookup(var.cpu_architecture_overrides, "metricwork", var.cpu_architecture)
   app              = "metricwork"
@@ -2999,7 +3016,7 @@ module "metricwork" {
 }
 
 module "rootcause" {
-  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key]
+  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key, aws_secretsmanager_secret_version.remember_me_cipher_key]
   source           = "../simpleservice"
   cpu_architecture = lookup(var.cpu_architecture_overrides, "rootcause", var.cpu_architecture)
   app              = "rootcause"
@@ -3082,7 +3099,7 @@ module "rootcause" {
 }
 
 module "internalapi" {
-  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key]
+  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key, aws_secretsmanager_secret_version.remember_me_cipher_key]
   source           = "../simpleservice"
   cpu_architecture = lookup(var.cpu_architecture_overrides, "internalapi", var.cpu_architecture)
   app              = "internalapi"
@@ -3205,7 +3222,7 @@ resource "aws_appautoscaling_policy" "internalapi_request_count_per_target" {
 }
 
 module "lineageapi" {
-  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key]
+  depends_on       = [aws_secretsmanager_secret_version.robot_password, aws_secretsmanager_secret_version.robot_agent_api_key, aws_secretsmanager_secret_version.remember_me_cipher_key]
   source           = "../simpleservice"
   cpu_architecture = lookup(var.cpu_architecture_overrides, "lineageapi", var.cpu_architecture)
   app              = "lineageapi"

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1810,6 +1810,12 @@ variable "datawatch_robot_agent_api_key_secret_arn" {
   default     = ""
 }
 
+variable "datawatch_remember_me_cipher_key_secret_arn" {
+  description = "ARN for the secretsmanager secret holding the Shiro remember-me cipher key. Must be a base64-encoded 128-bit (16 byte) value. One will be created if not provided"
+  type        = string
+  default     = ""
+}
+
 variable "datawatch_base_salt_secret_arn" {
   description = "ARN for secretsmanager secret holding the base salt value. This will be used for securely storing sensitive information such as connection info. One will be created if not provided."
   type        = string


### PR DESCRIPTION
## Summary
- Adds `REMEMBER_ME_CIPHER_KEY` to the datawatch-family services' secrets (`datawatch`, `datawork`, `backfillwork`, `indexwork`, `lineagework`, `metricwork`, `rootcause`, `internalapi`, `lineageapi`), sourced from a new `datawatch_remember_me_cipher_key_secret_arn` variable — auto-created if not supplied, matching the existing `ROBOT_PASSWORD` pattern.
- The auto-generated value is produced via `random_id` (16 bytes) and its `b64_std` attribute, giving a base64-encoded 128-bit value suitable for Shiro's remember-me cipher key.

## Test plan
- [x] `terraform fmt`
- [x] `terraform validate`
- [ ] `terraform plan` against a real workspace to confirm the new secret/env var appear as expected