### PR TITLE
[SRE-7491] Fix terraform-modules publish notifications (use org SLACK channel variable)

### DIFF
--- a/.github/workflows/test_and_publish.yaml
+++ b/.github/workflows/test_and_publish.yaml
@@ -164,7 +164,7 @@ jobs:
           token:  ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           payload-templated: true
           payload: |
-            channel: ${{ secrets.SRE_SLACK_CHANNEL_ID }}
+            channel: ${{ vars.SLACK_CHANNEL_ID_SRE }}
             text: ":shipitparrot: terraform-modules successfully published version ${{ needs.publish.outputs.tag }}. [<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.publish.outputs.tag }}|Release>]" 
 
   notify-on-fail:
@@ -183,5 +183,5 @@ jobs:
           token:  ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           payload-templated: true
           payload: |
-            channel: ${{ secrets.SRE_SLACK_CHANNEL_ID }}            
+            channel: ${{ vars.SLACK_CHANNEL_ID_SRE }}            
             text: ":sadparrot: terraform-modules publish version ${{ needs.publish.outputs.tag }} failed. [<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| GH Action>]"


### PR DESCRIPTION
## Why

self-explained in title