### PR TITLE
feat: add REMEMBER_ME_OLD_CIPHER_KEY for cipher key rotation

### DIFF
--- a/modules/bigeye/locals.tf
+++ b/modules/bigeye/locals.tf
@@ -262,6 +262,10 @@ locals {
     MC_PASSWORD = var.datawatch_lineageplus_password_secret_arn
   } : {}
 
+  remember_me_old_cipher_key_secrets_map = var.datawatch_remember_me_old_cipher_key_secret_arn != "" ? {
+    REMEMBER_ME_OLD_CIPHER_KEY = var.datawatch_remember_me_old_cipher_key_secret_arn
+  } : {}
+
   datawatch_secret_arns = merge(
     local.auth0_secrets_map,
     local.slack_secrets_map,
@@ -269,6 +273,7 @@ locals {
     local.sentry_dsn_secret_map,
     local.byomailserver_smtp_password_secrets_map,
     local.datawatch_lineageplus_secrets_map,
+    local.remember_me_old_cipher_key_secrets_map,
     {
       REDIS_PRIMARY_PASSWORD = local.redis_auth_token_secret_arn
       MQ_BROKER_PASSWORD     = local.rabbitmq_user_password_secret_arn

--- a/modules/bigeye/variables.tf
+++ b/modules/bigeye/variables.tf
@@ -1816,6 +1816,12 @@ variable "datawatch_remember_me_cipher_key_secret_arn" {
   default     = ""
 }
 
+variable "datawatch_remember_me_old_cipher_key_secret_arn" {
+  description = "ARN for the secretsmanager secret holding the previous Shiro remember-me cipher key, used only as a decrypt fallback while rotating REMEMBER_ME_CIPHER_KEY. Leave empty (default) when not rotating -- REMEMBER_ME_OLD_CIPHER_KEY will not be injected. Unlike the other secrets here, none is auto-created since its value must be operator-controlled during rotation."
+  type        = string
+  default     = ""
+}
+
 variable "datawatch_base_salt_secret_arn" {
   description = "ARN for secretsmanager secret holding the base salt value. This will be used for securely storing sensitive information such as connection info. One will be created if not provided."
   type        = string


### PR DESCRIPTION
## Summary
- Adds `datawatch_remember_me_old_cipher_key_secret_arn` input, wired into `datawatch_secret_arns` as `REMEMBER_ME_OLD_CIPHER_KEY` only when set, so datawatch can decrypt remember-me cookies with a prior key while `REMEMBER_ME_CIPHER_KEY` is being rotated.
- Deliberately no auto-generated secret here (unlike the other `datawatch_*_secret_arn` vars) — the value must be operator-controlled during rotation, and is intentionally omitted when unset.

## Rotation procedure (consumer side, e.g. infra-as-code)
1. Stage the new key value into the old-cipher-key secret, redeploy, wait for full rollout (safe: nothing encrypts with it yet).
2. Swap secret values: new key becomes `REMEMBER_ME_CIPHER_KEY`, previous key becomes `REMEMBER_ME_OLD_CIPHER_KEY`. Redeploy.
3. (Optional) Once past the remember-me cookie's max age, remove the old-cipher-key wiring/secret. Redeploy.

## Test plan
- [x] `terraform fmt` clean
- [x] `terraform validate` passes on `modules/bigeye`
- [ ] First rollout being wired into `test-adhoc01` in `infra-as-code`